### PR TITLE
support custom digest for key

### DIFF
--- a/key.go
+++ b/key.go
@@ -97,6 +97,30 @@ func NewKey(namespace string, setName string, key interface{}) (newKey *Key, err
 	return newKey, err
 }
 
+// NewKey initializes a key from namespace, optional set name and user key.
+// The server handles record identifiers by digest only.
+func NewKeyWithDigest(namespace string, setName string, key interface{}, digest []byte) (newKey *Key, err error) {
+	newKey = &Key{
+		namespace: namespace,
+		setName:   setName,
+		userKey:   NewValue(key),
+	}
+
+	if err = newKey.SetDigest(digest); err != nil {
+		return nil, err
+	}
+	return newKey, err
+}
+
+//Set custom hash
+func (ky *Key) SetDigest(digest []byte) error {
+	if len(digest) != 20 {
+		return NewAerospikeError(PARAMETER_ERROR, "Invalid digest: not 20 byte")
+	}
+	ky.digest = digest
+	return nil
+}
+
 // Generate unique server hash value from set name, key type and user defined key.
 // The hash function is RIPEMD-160 (a 160 bit hash).
 func computeDigest(key *Key) ([]byte, error) {

--- a/key_test.go
+++ b/key_test.go
@@ -136,6 +136,17 @@ var _ = Describe("Key Test", func() {
 
 		})
 
+		It("for custom digest", func() {
+			key, _ := NewKey("namespace", "set", []interface{}{})
+			Expect(hex.EncodeToString(key.Digest())).To(Equal("2af0111192df4ca297232d1641ff52c2ce51ce2d"))
+			err := key.SetDigest([]byte("01234567890123456789"))
+			Expect(err, nil)
+			Expect(key.Digest()).To(Equal([]byte("01234567890123456789")))
+
+			key, _ = NewKeyWithDigest("namespace", "set", []interface{}{}, []byte("01234567890123456789"))
+			Expect(key.Digest()).To(Equal([]byte("01234567890123456789")))
+		})
+
 	})
 
 })


### PR DESCRIPTION
I would like to add a new method which return a key with custom digest.

```
var key aerospike.Key = NewKeyWithDigest(…, digest)
```

Sometimes I want delete item which fetched from query, but I can't because I don't have primary_key.
