### PR TITLE
Remove unsafe

### DIFF
--- a/utils/buffer/buffer.go
+++ b/utils/buffer/buffer.go
@@ -38,14 +38,11 @@ var Arch64Bits = (sizeOfInt == sizeOfInt64)
 var Arch32Bits = (sizeOfInt == sizeOfInt32)
 
 func init() {
-	var j, i int = 0, ^0
-
-	for i != 0 {
-		j++
-		i >>= 1
+	if int(^0) == 0xffffffff {
+		sizeOfInt = 4
+	} else {
+		sizeOfInt = 8
 	}
-
-	sizeOfInt = uintptr(j)
 }
 
 // Coverts a byte slice into a hex string

--- a/utils/buffer/buffer.go
+++ b/utils/buffer/buffer.go
@@ -38,7 +38,7 @@ var Arch64Bits = (sizeOfInt == sizeOfInt64)
 var Arch32Bits = (sizeOfInt == sizeOfInt32)
 
 func init() {
-	var j, i int = ^0
+	var j, i int = 0, ^0
 
 	for i != 0 {
 		j++

--- a/utils/buffer/buffer.go
+++ b/utils/buffer/buffer.go
@@ -19,24 +19,34 @@ import (
 	// "errors"
 	"fmt"
 	"math"
-	"unsafe"
 
 	// . "github.com/aerospike/aerospike-client-go/logger"
 )
 
-var sizeOfInt = unsafe.Sizeof(int(0))
-var sizeOfInt32 = unsafe.Sizeof(int32(0))
-var sizeOfInt64 = unsafe.Sizeof(int64(0))
+var sizeOfInt uintptr
+var sizeOfInt32 = uintptr(4)
+var sizeOfInt64 = uintptr(8)
 
-var uint64sz = int(unsafe.Sizeof(uint64(0)))
-var uint32sz = int(unsafe.Sizeof(uint32(0)))
-var uint16sz = int(unsafe.Sizeof(uint16(0)))
+var uint64sz = int(8)
+var uint32sz = int(4)
+var uint16sz = int(2)
 
-var float32sz = int(unsafe.Sizeof(float32(0)))
-var float64sz = int(unsafe.Sizeof(float64(0)))
+var float32sz = int(4)
+var float64sz = int(8)
 
 var Arch64Bits = (sizeOfInt == sizeOfInt64)
 var Arch32Bits = (sizeOfInt == sizeOfInt32)
+
+func init() {
+	var j, i int = ^0
+
+	for i != 0 {
+		j++
+		i >>= 1
+	}
+
+	sizeOfInt = uintptr(j)
+}
 
 // Coverts a byte slice into a hex string
 func BytesToHexString(buf []byte) string {

--- a/value.go
+++ b/value.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	// . "github.com/aerospike/aerospike-client-go/logger"
 	. "github.com/aerospike/aerospike-client-go/types"
@@ -66,8 +65,20 @@ type AerospikeBlob interface {
 	EncodeBlob() ([]byte, error)
 }
 
-var sizeOfInt = unsafe.Sizeof(int(0))
-var sizeOfInt32 = unsafe.Sizeof(int32(0))
+var sizeOfInt uintptr
+var sizeOfInt32 = uintptr(4)
+var sizeOfInt64 = uintptr(8)
+
+func init() {
+	var j, i int = 0, ^0
+
+	for i != 0 {
+		j++
+		i >>= 1
+	}
+
+	sizeOfInt = uintptr(j)
+}
 
 // NewValue generates a new Value object based on the type.
 // If the type is not supported, NewValue will panic.

--- a/value.go
+++ b/value.go
@@ -70,14 +70,11 @@ var sizeOfInt32 = uintptr(4)
 var sizeOfInt64 = uintptr(8)
 
 func init() {
-	var j, i int = 0, ^0
-
-	for i != 0 {
-		j++
-		i >>= 1
+	if int(^0) == 0xffffffff {
+		sizeOfInt = 4
+	} else {
+		sizeOfInt = 8
 	}
-
-	sizeOfInt = uintptr(j)
 }
 
 // NewValue generates a new Value object based on the type.

--- a/value_test.go
+++ b/value_test.go
@@ -17,7 +17,6 @@ package aerospike
 import (
 	"math"
 	"reflect"
-	"unsafe"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -38,7 +37,7 @@ func (b *testBLOB) EncodeBlob() ([]byte, error) {
 func isValidIntegerValue(i int, v Value) bool {
 	Expect(reflect.TypeOf(v)).To(Equal(reflect.TypeOf(NewIntegerValue(0))))
 	Expect(v.GetObject()).To(Equal(i))
-	Expect(v.estimateSize()).To(Equal(int(unsafe.Sizeof(int(0)))))
+	Expect(v.estimateSize()).To(Equal(int(sizeOfInt)))
 	Expect(v.GetType()).To(Equal(ParticleType.INTEGER))
 
 	return true
@@ -47,7 +46,7 @@ func isValidIntegerValue(i int, v Value) bool {
 func isValidLongValue(i int64, v Value) bool {
 	Expect(reflect.TypeOf(v)).To(Equal(reflect.TypeOf(NewLongValue(0))))
 	Expect(v.GetObject().(int64)).To(Equal(i))
-	Expect(v.estimateSize()).To(Equal(int(unsafe.Sizeof(int64(0)))))
+	Expect(v.estimateSize()).To(Equal(int(sizeOfInt64)))
 	Expect(v.GetType()).To(Equal(ParticleType.INTEGER))
 
 	return true


### PR DESCRIPTION
Please review the remove unsafe change.

This change removes uses of unsafe for deploying an aerospike client to the google app engine.