### PR TITLE
Fix simpler method to find int size

### DIFF
--- a/utils/buffer/buffer.go
+++ b/utils/buffer/buffer.go
@@ -38,7 +38,7 @@ var Arch64Bits bool
 var Arch32Bits bool
 
 func init() {
-	if int(^0) == 0xffffffff {
+	if 0 == ^uint(0xffffffff) {
 		sizeOfInt = 4
 	} else {
 		sizeOfInt = 8

--- a/value.go
+++ b/value.go
@@ -70,7 +70,7 @@ var sizeOfInt32 = uintptr(4)
 var sizeOfInt64 = uintptr(8)
 
 func init() {
-	if int(^0) == 0xffffffff {
+	if 0 == ^uint(0xffffffff) {
 		sizeOfInt = 4
 	} else {
 		sizeOfInt = 8


### PR DESCRIPTION
previous didn't work on 32bit (I'm so sorry)

make sure it works ok on 32-bit (go playground):

http://play.golang.org/p/Hceoxd9J_h