### PR TITLE
Fix: newBatchCommandGet() ignoring binNames restrictions

### DIFF
--- a/batch_command_get.go
+++ b/batch_command_get.go
@@ -45,6 +45,7 @@ func newBatchCommandGet(
 		batchNamespace:   batchNamespace,
 		policy:           policy,
 		keyMap:           keyMap,
+		binNames:         binNames,
 		records:          records,
 		readAttr:         readAttr,
 	}


### PR DESCRIPTION
At present, BatchGet(policy BasePolicy, keys *[]Key, bins ...string) ([]Record, error) altogether ignores the |bins| argument. Looks like it's omitted in newBatchCommandGet(), and with this CL I'm seeing restrictions being correctly applied.