### PR TITLE
Added IdleTimeout to ClientPolicy to manage idle connections

### DIFF
--- a/client_policy.go
+++ b/client_policy.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+const defaultIdleTimeout = 14 * time.Second
+
 // ClientPolicy encapsulates parameters for client policy command.
 type ClientPolicy struct {
 	// User authentication to cluster. Leave empty for clusters running without restricted access.
@@ -30,6 +32,11 @@ type ClientPolicy struct {
 	// Initial host connection timeout in milliseconds.  The timeout when opening a connection
 	// to the server host for the first time.
 	Timeout time.Duration //= 1 second
+
+	// Connection idle timeout. Every time a connection is used, its idle
+	// deadline will be extended by this duration. When this deadline is reached,
+	// the connection will be closed and discarded from the connection pool.
+	IdleTimeout time.Duration //= 14 seconds
 
 	// Size of the Connection Queue cache.
 	ConnectionQueueSize int //= 256
@@ -50,6 +57,7 @@ type ClientPolicy struct {
 func NewClientPolicy() *ClientPolicy {
 	return &ClientPolicy{
 		Timeout:                     time.Second,
+		IdleTimeout:                 defaultIdleTimeout,
 		ConnectionQueueSize:         256,
 		FailIfNotConnected:          true,
 		TendInterval:                time.Second,

--- a/connection.go
+++ b/connection.go
@@ -27,6 +27,10 @@ type Connection struct {
 	// timeout
 	timeout time.Duration
 
+	// duration after which connection is considered idle
+	idleTimeout  time.Duration
+	idleDeadline time.Time
+
 	// connection object
 	conn net.Conn
 }
@@ -146,4 +150,19 @@ func (ctn *Connection) Authenticate(user string, password []byte) error {
 		}
 	}
 	return nil
+}
+
+// setIdleTimeout sets the idle timeout for the connection.
+func (ctn *Connection) setIdleTimeout(timeout time.Duration) {
+	ctn.idleTimeout = timeout
+}
+
+// isIdle returns true if the connection has reached the idle deadline.
+func (ctn *Connection) isIdle() bool {
+	return !time.Now().Before(ctn.idleDeadline)
+}
+
+// refresh extends the idle deadline of the connection.
+func (ctn *Connection) refresh() {
+	ctn.idleDeadline = time.Now().Add(ctn.idleTimeout)
 }


### PR DESCRIPTION
I have added a ```MaxIdle``` option to ClientPolicy to tackle the following problems:

#### Problem 1:

Because the connection pool is a FIFO queue, and because the "tend" logic of updating
information about the cluster gets connection after connection from the pool every TendInterval slices,
there will be cases where lots of connections are unnecessarily "kept open" in the pool, depending on the client's TendInterval value (1s by default) and aerospike server's proto-fd-idle-ms (60s by default).
By default, once we manage to get more than 60 connections in the pool, the first 60 will probably never be closed, assuming no errors occur, even when there is no load at all for some time.

When some connection request peak is over, we will in most cases want to
close those connections after some time, and remove pressure of handling so many unnecessary
connections from our side (the aerospike client) and from aerospike servers.

#### Problem 2:

A period of connection peaks that creates 256 connections in the pool, followed by a proto-fd-idle-ms (60s by default) period of no activity, followed again by a significant new peak of 256 connections, will cause something like (256-60) 196 connections to get killed by aerospike servers. Since aerospike-client-go only detects these connections as closed only when it fails to read/write something from/to them, this will cause intermittent failures during commands to the database in the second peak due to EOF errors of connections that are "long dead" but not promptly detected by the client.

#### Solution Proposal

I propose the use of a MaxIdle setting for controlling the "freshness" of a connection.

I decide to call it "Idle" and to give it the default value of 14 after I seeing aerospike-client-c defines this variable (it is not implemented yet though):

http://www.aerospike.com/apidocs/c/d0/d99/structas__config.html#a552c3c70ed3340101f1f150d57b7cdde

I try to tackle this problem with this PR.
I have some doubts about some decisions I took:

- Naming: ```MaxIdle```, ```IsFresh```, ```Refresh```, etc. Does it look OK to you?
- ```PutConnection``` could do the ```conn.Refresh()``` automatically, but I decided that having more control over the connection would be better (example follows)
- The only place I do not refresh the connection is in the ```node.Refresh``` function. I am not sure if we should just refresh it here too, but I am concerned with Problem 1.
- I have done nothing about it for fear of being too disruptive or that you would immediately not accept the whole PR, but the above two doubts wouldn't exist if the connection queue were actually a stack. So, if we had a period no (or almost no) activity, only 1 connection would be used for the ```node.Refresh``` logic. Since I have done nothing about this point, the current state says that once we get more than MaxIdle/TendInterval (14) connections in the queue, they will be kept open. If we do it with a stack,  we will go down to 1 connection.

What do you think?

By the way I ran the tests and all passed, except the ones associated with LDT's GetCapacity/SetCapacity.

Apparently they were removed from aerospike as a reflection of https://github.com/aerospike/aerospike-lua-core/commit/7639667dc8f2ac4c40e6ed02f597056e2fe7dd37

I believe this should be fixed in a different PR, so I have done nothing to fix it here.