### PR TITLE
Fixed error handling on authentication failure

### DIFF
--- a/node.go
+++ b/node.go
@@ -220,14 +220,14 @@ L:
 		}
 
 		// need to authenticate
-		if conn.Authenticate(nd.cluster.user, nd.cluster.password); err != nil {
+		if err = conn.Authenticate(nd.cluster.user, nd.cluster.password); err != nil {
 			// Socket not authenticated. Do not put back into pool.
 			conn.Close()
 
 			return nil, err
 		}
 
-		if conn.SetTimeout(timeout) != nil {
+		if err = conn.SetTimeout(timeout); err != nil {
 			// Socket not authenticated. Do not put back into pool.
 			conn.Close()
 			return nil, err

--- a/node_test.go
+++ b/node_test.go
@@ -38,6 +38,28 @@ var _ = Describe("Aerospike", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		Context("When Authentication is Used", func() {
+			It("must return error if it fails to authenticate", func() {
+				clientPolicy := NewClientPolicy()
+				clientPolicy.User = "non_existent_user"
+				clientPolicy.Password = "non_existent_user"
+
+				client, err = NewClientWithPolicy(clientPolicy, *host, *port)
+				Expect(err).ToNot(HaveOccurred())
+				defer client.Close()
+
+				node := client.GetNodes()[0]
+
+				for i := 0; i < 20; i++ {
+					c, err := node.GetConnection(0)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("Authentication failed"))
+					Expect(c).To(BeNil())
+				}
+
+			})
+		})
+
 		Context("When No Connection Count Limit Is Set", func() {
 
 			It("must return a new connection on every poll", func() {


### PR DESCRIPTION
Even on authentication failure, no errors are returned due to improper error handling.
This PR is an attempt to fix it.
The same problem may also occur when calling SetTimeout, but since it is not currently possible to test that and the fix is similar, I am including in the same PR.