### PR TITLE
Fixed invalid connection handling on node connections

### DIFF
--- a/admin_command.go
+++ b/admin_command.go
@@ -244,12 +244,12 @@ func (acmd *AdminCommand) executeCommand(cluster *Cluster, policy *AdminPolicy) 
 	}
 
 	if _, err := conn.Write(acmd.dataBuffer[:acmd.dataOffset]); err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return err
 	}
 
 	if _, err := conn.Read(acmd.dataBuffer, _HEADER_SIZE); err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return err
 	}
 
@@ -280,12 +280,13 @@ func (acmd *AdminCommand) readUsers(cluster *Cluster, policy *AdminPolicy) ([]*U
 	}
 
 	if _, err := conn.Write(acmd.dataBuffer[:acmd.dataOffset]); err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
 
 	status, list, err := acmd.readUserBlocks(conn)
 	if err != nil {
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
 	node.PutConnection(conn)

--- a/client.go
+++ b/client.go
@@ -596,9 +596,10 @@ func (clnt *Client) RegisterUDF(policy *WritePolicy, udfBody []byte, serverPath 
 
 	responseMap, err := RequestInfo(conn, strCmd.String())
 	if err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
+	node.PutConnection(conn)
 
 	var response string
 	for _, v := range responseMap {
@@ -622,8 +623,6 @@ func (clnt *Client) RegisterUDF(policy *WritePolicy, udfBody []byte, serverPath 
 		return nil, NewAerospikeError(COMMAND_REJECTED, fmt.Sprintf("Registration failed: %s\nFile: %s\nLine: %s\nMessage: %s",
 			res["error"], res["file"], res["line"], res["message"]))
 	}
-
-	node.PutConnection(conn)
 	return NewRegisterTask(clnt.cluster, serverPath), nil
 }
 
@@ -656,9 +655,10 @@ func (clnt *Client) RemoveUDF(policy *WritePolicy, udfName string) (*RemoveTask,
 
 	responseMap, err := RequestInfo(conn, strCmd.String())
 	if err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
+	node.PutConnection(conn)
 
 	var response string
 	for _, v := range responseMap {
@@ -697,9 +697,10 @@ func (clnt *Client) ListUDF(policy *BasePolicy) ([]*UDF, error) {
 
 	responseMap, err := RequestInfo(conn, strCmd.String())
 	if err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
+	node.PutConnection(conn)
 
 	var response string
 	for _, v := range responseMap {
@@ -733,8 +734,6 @@ func (clnt *Client) ListUDF(policy *BasePolicy) ([]*UDF, error) {
 		}
 		res = append(res, udf)
 	}
-
-	node.PutConnection(conn)
 
 	return res, nil
 }
@@ -1120,7 +1119,7 @@ func (clnt *Client) sendInfoCommand(policy *WritePolicy, command string) (map[st
 
 	info, err := newInfo(conn, command)
 	if err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
 	node.PutConnection(conn)

--- a/command.go
+++ b/command.go
@@ -786,7 +786,7 @@ func (cmd *baseCommand) execute(ifc command) (err error) {
 		if err != nil {
 			// All runtime exceptions are considered fatal. Do not retry.
 			// Close socket to flush out possible garbage. Do not put back in pool.
-			cmd.conn.Close()
+			node.InvalidateConnection(cmd.conn)
 			return err
 		}
 
@@ -798,7 +798,7 @@ func (cmd *baseCommand) execute(ifc command) (err error) {
 		if err != nil {
 			// IO errors are considered temporary anomalies. Retry.
 			// Close socket to flush out possible garbage. Do not put back in pool.
-			cmd.conn.Close()
+			node.InvalidateConnection(cmd.conn)
 
 			Logger.Warn("Node " + node.String() + ": " + err.Error())
 			// IO error means connection to server node is unhealthy.
@@ -814,7 +814,7 @@ func (cmd *baseCommand) execute(ifc command) (err error) {
 			// cancelling/closing the batch/multi commands will return an error, which will
 			// close the connection to throw away its data and signal the server about the
 			// situation. We will not put back the connection in the buffer.
-			cmd.conn.Close()
+			node.InvalidateConnection(cmd.conn)
 			return err
 		}
 

--- a/execute_task.go
+++ b/execute_task.go
@@ -57,6 +57,7 @@ func (etsk *ExecuteTask) IsDone() (bool, error) {
 		}
 		responseMap, err := RequestInfo(conn, command)
 		if err != nil {
+			node.InvalidateConnection(conn)
 			return false, err
 		}
 

--- a/info.go
+++ b/info.go
@@ -43,7 +43,7 @@ func RequestNodeInfo(node *Node, name ...string) (map[string]string, error) {
 
 	response, err := RequestInfo(conn, name...)
 	if err != nil {
-		conn.Close()
+		node.InvalidateConnection(conn)
 		return nil, err
 	}
 	node.PutConnection(conn)

--- a/node_test.go
+++ b/node_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Aerospike", func() {
 					Expect(c).NotTo(BeNil())
 					Expect(c.IsConnected()).To(BeTrue())
 
-					c.Close()
+					node.InvalidateConnection(c)
 				}
 
 			})
@@ -104,7 +104,7 @@ var _ = Describe("Aerospike", func() {
 					Expect(c).NotTo(BeNil())
 					Expect(c.IsConnected()).To(BeTrue())
 
-					c.Close()
+					node.InvalidateConnection(c)
 				}
 
 				for i := 0; i < 4; i++ {
@@ -260,7 +260,7 @@ var _ = Describe("Aerospike", func() {
 				c3, err := node.GetConnection(0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c3).NotTo(BeNil())
-				defer c3.Close()
+				defer node.InvalidateConnection(c3)
 				Expect(c3).ToNot(Equal(c))
 				Expect(c3.IsConnected()).To(BeTrue())
 

--- a/security_test.go
+++ b/security_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Security tests", func() {
 					for i := 0; i < client_policy.ConnectionQueueSize; i++ {
 						conn, err := node.GetConnection(time.Second)
 						Expect(err).ToNot(HaveOccurred())
-						conn.Close()
+						node.InvalidateConnection(conn)
 					}
 				}
 

--- a/tools/asinfo/asinfo.go
+++ b/tools/asinfo/asinfo.go
@@ -52,8 +52,10 @@ func main() {
 			log.Fatalln(err.Error())
 		} else {
 			if infoMap, err := as.RequestInfo(conn, strings.Trim(*value, " ")); err != nil {
+				node.InvalidateConnection(conn)
 				log.Fatalln(err.Error())
 			} else {
+				node.PutConnection(conn)
 				cnt := 1
 				for k, v := range infoMap {
 					log.Printf("%d :  %s\n     %s\n\n", cnt, k, v)


### PR DESCRIPTION
I realized that Node connectionCount is not decrement when connections don't return through PutConnection.

There is a possibility to block new connection if LimitConnectionsToQueueSize is true and connections have some problems.

This PR is an attempt to fix it.

I'm not sure whether the connection pool handling on Node.Refresh is correct or not...