### PR TITLE
Small fixes to the (*Recordset).Results() comment

### DIFF
--- a/recordset.go
+++ b/recordset.go
@@ -64,24 +64,24 @@ func (rcs *Recordset) IsActive() bool {
 	return rcs.active.Get()
 }
 
-// Results returns a new receive-only channel with the results of the Scan/Query
+// Results returns a new receive-only channel with the results of the Scan/Query.
 // This is a more idiomatic approach to the iterator pattern in getting the
 // results back from the recordset, and doesn't require the user to write the
 // ugly select in their code.
-// Result embeds A Record and an error reference.
+// Result contains a Record and an error reference.
 //
 // Example:
 //
-// recordset, err := client.ScanAll(nil, namespace, set)
-// handleError(err)
-// for res := range recordset.Results() {
-//   if res.Err != nil {
-//     // handle error here
-//   } else {
-//     // process record here
-//     fmt.Println(res.Record.Bins)
-//   }
-// }
+//  recordset, err := client.ScanAll(nil, namespace, set)
+//  handleError(err)
+//  for res := range recordset.Results() {
+//    if res.Err != nil {
+//      // handle error here
+//    } else {
+//      // process record here
+//      fmt.Println(res.Record.Bins)
+//    }
+//  }
 func (rcs *Recordset) Results() <-chan *Result {
 	res := make(chan *Result, len(rcs.Records))
 


### PR DESCRIPTION
The `Result` type contains a `Record` as a field. It's not embedded. If `Record` was embedded then it would be possible to reference all the fields of Record directly on Result. e.g. `result.Key` instead of `result.Record.Key`.

Also fixed the example, it needs an extra space indentation to be rendered correctly by godoc.