### PR TITLE
Fix a bunch of golint notices.

### DIFF
--- a/admin_policy.go
+++ b/admin_policy.go
@@ -16,7 +16,7 @@ package aerospike
 
 import "time"
 
-// Policy attributes used for user administration commands.
+// AdminPolicy contains attributes used for user administration commands.
 type AdminPolicy struct {
 
 	// User administration command socket timeout in milliseconds.

--- a/client.go
+++ b/client.go
@@ -1025,7 +1025,7 @@ func (clnt *Client) DropIndex(
 // User administration
 //-------------------------------------------------------
 
-// Create user with password and roles. Clear-text password will be hashed using bcrypt
+// CreateUser creates a new user with password and roles. Clear-text password will be hashed using bcrypt
 // before sending to server.
 func (clnt *Client) CreateUser(policy *AdminPolicy, user string, password string, roles []string) error {
 	policy = clnt.getUsableAdminPolicy(policy)
@@ -1038,7 +1038,7 @@ func (clnt *Client) CreateUser(policy *AdminPolicy, user string, password string
 	return command.createUser(clnt.cluster, policy, user, hash, roles)
 }
 
-// Remove user from cluster.
+// DropUser removes a user from the cluster.
 func (clnt *Client) DropUser(policy *AdminPolicy, user string) error {
 	policy = clnt.getUsableAdminPolicy(policy)
 
@@ -1046,7 +1046,7 @@ func (clnt *Client) DropUser(policy *AdminPolicy, user string) error {
 	return command.dropUser(clnt.cluster, policy, user)
 }
 
-// Change user's password. Clear-text password will be hashed using bcrypt before sending to server.
+// ChangePassword changes a user's password. Clear-text password will be hashed using bcrypt before sending to server.
 func (clnt *Client) ChangePassword(policy *AdminPolicy, user string, password string) error {
 	policy = clnt.getUsableAdminPolicy(policy)
 
@@ -1077,7 +1077,7 @@ func (clnt *Client) ChangePassword(policy *AdminPolicy, user string, password st
 	return nil
 }
 
-// Add roles to user's list of roles.
+// GrantRoles adds roles to user's list of roles.
 func (clnt *Client) GrantRoles(policy *AdminPolicy, user string, roles []string) error {
 	policy = clnt.getUsableAdminPolicy(policy)
 
@@ -1085,7 +1085,7 @@ func (clnt *Client) GrantRoles(policy *AdminPolicy, user string, roles []string)
 	return command.grantRoles(clnt.cluster, policy, user, roles)
 }
 
-// Remove roles from user's list of roles.
+// RevokeRoles removes roles from user's list of roles.
 func (clnt *Client) RevokeRoles(policy *AdminPolicy, user string, roles []string) error {
 	policy = clnt.getUsableAdminPolicy(policy)
 
@@ -1093,7 +1093,7 @@ func (clnt *Client) RevokeRoles(policy *AdminPolicy, user string, roles []string
 	return command.revokeRoles(clnt.cluster, policy, user, roles)
 }
 
-// Retrieve roles for a given user.
+// QueryUser retrieves roles for a given user.
 func (clnt *Client) QueryUser(policy *AdminPolicy, user string) (*UserRoles, error) {
 	policy = clnt.getUsableAdminPolicy(policy)
 
@@ -1101,7 +1101,7 @@ func (clnt *Client) QueryUser(policy *AdminPolicy, user string) (*UserRoles, err
 	return command.queryUser(clnt.cluster, policy, user)
 }
 
-// Retrieve all users and their roles.
+// QueryUsers retrieves all users and their roles.
 func (clnt *Client) QueryUsers(policy *AdminPolicy) ([]*UserRoles, error) {
 	policy = clnt.getUsableAdminPolicy(policy)
 
@@ -1179,9 +1179,8 @@ func (clnt *Client) getUsablePolicy(policy *BasePolicy) *BasePolicy {
 	if policy == nil {
 		if clnt.DefaultPolicy != nil {
 			return clnt.DefaultPolicy
-		} else {
-			return NewPolicy()
 		}
+		return NewPolicy()
 	}
 	return policy
 }
@@ -1190,9 +1189,8 @@ func (clnt *Client) getUsableWritePolicy(policy *WritePolicy) *WritePolicy {
 	if policy == nil {
 		if clnt.DefaultWritePolicy != nil {
 			return clnt.DefaultWritePolicy
-		} else {
-			return NewWritePolicy(0, 0)
 		}
+		return NewWritePolicy(0, 0)
 	}
 	return policy
 }
@@ -1201,9 +1199,8 @@ func (clnt *Client) getUsableScanPolicy(policy *ScanPolicy) *ScanPolicy {
 	if policy == nil {
 		if clnt.DefaultScanPolicy != nil {
 			return clnt.DefaultScanPolicy
-		} else {
-			return NewScanPolicy()
 		}
+		return NewScanPolicy()
 	}
 	return policy
 }
@@ -1211,10 +1208,9 @@ func (clnt *Client) getUsableScanPolicy(policy *ScanPolicy) *ScanPolicy {
 func (clnt *Client) getUsableQueryPolicy(policy *QueryPolicy) *QueryPolicy {
 	if policy == nil {
 		if clnt.DefaultQueryPolicy != nil {
-			policy = clnt.DefaultQueryPolicy
-		} else {
-			policy = NewQueryPolicy()
+			return clnt.DefaultQueryPolicy
 		}
+		return NewQueryPolicy()
 	}
 	return policy
 }
@@ -1222,10 +1218,9 @@ func (clnt *Client) getUsableQueryPolicy(policy *QueryPolicy) *QueryPolicy {
 func (clnt *Client) getUsableAdminPolicy(policy *AdminPolicy) *AdminPolicy {
 	if policy == nil {
 		if clnt.DefaultAdminPolicy != nil {
-			policy = clnt.DefaultAdminPolicy
-		} else {
-			policy = NewAdminPolicy()
+			return clnt.DefaultAdminPolicy
 		}
+		return NewAdminPolicy()
 	}
 	return policy
 }

--- a/cluster.go
+++ b/cluster.go
@@ -702,6 +702,7 @@ func (clstr *Cluster) WaitUntillMigrationIsFinished(timeout time.Duration) (err 
 	}
 }
 
+// Password returns the password that is currently used with the cluster.
 func (clstr *Cluster) Password() (res []byte) {
 	clstr.mutex.RLock()
 	res = clstr.password
@@ -720,6 +721,7 @@ func (clstr *Cluster) changePassword(user string, password string, hash []byte) 
 	}
 }
 
+// ClientPolicy returns the client policy that is currently used with the cluster.
 func (clstr *Cluster) ClientPolicy() (res ClientPolicy) {
 	clstr.mutex.RLock()
 	res = clstr.clientPolicy

--- a/commit_policy.go
+++ b/commit_policy.go
@@ -17,13 +17,13 @@
 
 package aerospike
 
-// Desired consistency guarantee when committing a transaction on the server.
+// CommitLevel indicates the desired consistency guarantee when committing a transaction on the server.
 type CommitLevel int
 
 const (
-	// Server should wait until successfully committing master and all replicas.
+	// COMMIT_ALL indicates the server should wait until successfully committing master and all replicas.
 	COMMIT_ALL CommitLevel = iota
 
-	// Server should wait until successfully committing master only.
+	// COMMIT_MASTER indicates the server should wait until successfully committing master only.
 	COMMIT_MASTER
 )

--- a/consistency_level.go
+++ b/consistency_level.go
@@ -17,14 +17,16 @@
 
 package aerospike
 
-// How replicas should be consulted in a read operation to provide the desired
-// consistency guarantee.
+// ConsistencyLevel indicates how replicas should be consulted in a read
+// operation to provide the desired consistency guarantee.
 type ConsistencyLevel int
 
 const (
-	// Involve a single replica in the operation.
+	// CONSISTENCY_ONE indicates only a single replica should be consulted in
+	// the read operation.
 	CONSISTENCY_ONE = iota
 
-	// Involve all replicas in the operation.
+	// CONSISTENCY_ALL indicates that all replicas should be consulted in
+	// the read operation.
 	CONSISTENCY_ALL
 )

--- a/field_type.go
+++ b/field_type.go
@@ -17,6 +17,7 @@ package aerospike
 // FieldType represents the type of the field in Aerospike Wire Protocol
 type FieldType int
 
+// FieldType constants used in the Aerospike Wire Protocol.
 const (
 	NAMESPACE FieldType = 0
 	TABLE     FieldType = 1

--- a/key.go
+++ b/key.go
@@ -97,7 +97,7 @@ func NewKey(namespace string, setName string, key interface{}) (newKey *Key, err
 	return newKey, err
 }
 
-// NewKey initializes a key from namespace, optional set name and user key.
+// NewKeyWithDigest initializes a key from namespace, optional set name and user key.
 // The server handles record identifiers by digest only.
 func NewKeyWithDigest(namespace string, setName string, key interface{}, digest []byte) (newKey *Key, err error) {
 	newKey = &Key{
@@ -112,7 +112,7 @@ func NewKeyWithDigest(namespace string, setName string, key interface{}, digest 
 	return newKey, err
 }
 
-//Set custom hash
+// SetDigest sets a custom hash
 func (ky *Key) SetDigest(digest []byte) error {
 	if len(digest) != 20 {
 		return NewAerospikeError(PARAMETER_ERROR, "Invalid digest: Digest is required to be exactly 20 bytes.")

--- a/large_list.go
+++ b/large_list.go
@@ -71,7 +71,7 @@ func (ll *LargeList) FindThenFilter(value interface{}, filterModule, filterName 
 	return res.([]interface{}), err
 }
 
-// Select values from the beginning of list up to a maximum count.
+// FindFirst selects values from the beginning of list up to a maximum count.
 func (ll *LargeList) FindFirst(count int) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_first", ll.binName, NewValue(count))
 	if err != nil {
@@ -84,7 +84,7 @@ func (ll *LargeList) FindFirst(count int) ([]interface{}, error) {
 	return res.([]interface{}), err
 }
 
-// Select values from the beginning of list up to a maximum count after applying lua filter.
+// FFilterThenindFirst selects values from the beginning of list up to a maximum count after applying lua filter.
 func (ll *LargeList) FFilterThenindFirst(count int, filterModule, filterName string, filterArgs ...interface{}) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_first", ll.binName, NewValue(count), NewValue(filterModule), NewValue(filterName), ToValueArray(filterArgs))
 	if err != nil {
@@ -97,7 +97,7 @@ func (ll *LargeList) FFilterThenindFirst(count int, filterModule, filterName str
 	return res.([]interface{}), err
 }
 
-// Select values from the end of list up to a maximum count.
+// FindLast selects values from the end of list up to a maximum count.
 func (ll *LargeList) FindLast(count int) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_last", ll.binName, NewValue(count))
 	if err != nil {
@@ -110,7 +110,7 @@ func (ll *LargeList) FindLast(count int) ([]interface{}, error) {
 	return res.([]interface{}), err
 }
 
-// Select values from the end of list up to a maximum count after applying lua filter.
+// FilterThenFindLast selects values from the end of list up to a maximum count after applying lua filter.
 func (ll *LargeList) FilterThenFindLast(count int, filterModule, filterName string, filterArgs ...interface{}) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_last", ll.binName, NewValue(count), NewValue(filterModule), NewValue(filterName), ToValueArray(filterArgs))
 	if err != nil {
@@ -123,7 +123,7 @@ func (ll *LargeList) FilterThenFindLast(count int, filterModule, filterName stri
 	return res.([]interface{}), err
 }
 
-// Select values from the begin key up to a maximum count.
+// FindFrom selects values from the begin key up to a maximum count.
 func (ll *LargeList) FindFrom(begin interface{}, count int) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_from", ll.binName, NewValue(begin), NewValue(count))
 	if err != nil {
@@ -136,7 +136,7 @@ func (ll *LargeList) FindFrom(begin interface{}, count int) ([]interface{}, erro
 	return res.([]interface{}), err
 }
 
-// Select values from the begin key up to a maximum count after applying lua filter.
+// FilterThenFindFrom selects values from the begin key up to a maximum count after applying lua filter.
 func (ll *LargeList) FilterThenFindFrom(begin interface{}, count int, filterModule, filterName string, filterArgs ...interface{}) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_from", ll.binName, NewValue(begin), NewValue(count), NewValue(filterModule), NewValue(filterName), ToValueArray(filterArgs))
 	if err != nil {
@@ -149,7 +149,7 @@ func (ll *LargeList) FilterThenFindFrom(begin interface{}, count int, filterModu
 	return res.([]interface{}), err
 }
 
-// Select a range of values from the large list.
+// Range selects a range of values from the large list.
 func (ll *LargeList) Range(begin, end interface{}) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_range", ll.binName, NewValue(begin), NewValue(end))
 	if err != nil {
@@ -162,7 +162,7 @@ func (ll *LargeList) Range(begin, end interface{}) ([]interface{}, error) {
 	return res.([]interface{}), err
 }
 
-// Select a range of values up to a maximum count from the large list.
+// RangeN selects a range of values up to a maximum count from the large list.
 func (ll *LargeList) RangeN(begin, end interface{}, count int) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "find_range", ll.binName, NewValue(begin), NewValue(end), NewValue(count))
 	if err != nil {
@@ -175,7 +175,7 @@ func (ll *LargeList) RangeN(begin, end interface{}, count int) ([]interface{}, e
 	return res.([]interface{}), err
 }
 
-// Select a range of values from the large list then apply filter.
+// RangeThenFilter selects a range of values from the large list then apply filter.
 func (ll *LargeList) RangeThenFilter(begin, end interface{}, filterModule string, filterName string, filterArgs ...interface{}) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "range", ll.binName, NewValue(begin), NewValue(end), NewValue(0), NewValue(filterModule), NewValue(filterName), ToValueArray(filterArgs))
 	if err != nil {
@@ -188,7 +188,7 @@ func (ll *LargeList) RangeThenFilter(begin, end interface{}, filterModule string
 	return res.([]interface{}), err
 }
 
-// Select a range of values up to a maximum count from the large list then apply filter.
+// RangeNThenFilter selects a range of values up to a maximum count from the large list then apply filter.
 func (ll *LargeList) RangeNThenFilter(begin, end interface{}, count int, filterModule string, filterName string, filterArgs ...interface{}) ([]interface{}, error) {
 	res, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "range", ll.binName, NewValue(begin), NewValue(end), NewValue(count), NewValue(filterModule), NewValue(filterName), ToValueArray(filterArgs))
 	if err != nil {
@@ -229,7 +229,7 @@ func (ll *LargeList) Size() (int, error) {
 	return ll.size(ll)
 }
 
-// Set LDT page size.
+// SetPageSize sets the LDT page size.
 func (ll *LargeList) SetPageSize(pageSize int) error {
 	_, err := ll.client.Execute(ll.policy, ll.key, ll.packageName, "setPageSize", ll.binName, NewValue(pageSize))
 	return err

--- a/large_map.go
+++ b/large_map.go
@@ -48,7 +48,7 @@ func (lm *LargeMap) PutMap(theMap map[interface{}]interface{}) error {
 	return err
 }
 
-// Check existence of key in the map.
+// Exists checks existence of key in the map.
 func (lm *LargeMap) Exists(keyValue interface{}) (bool, error) {
 	res, err := lm.client.Execute(lm.policy, lm.key, lm.packageName, "exists", lm.binName, NewValue(keyValue))
 
@@ -62,7 +62,7 @@ func (lm *LargeMap) Exists(keyValue interface{}) (bool, error) {
 	return (res.(int) != 0), err
 }
 
-// Get returns  value from map corresponding with the provided key.
+// Get returns value from map corresponding with the provided key.
 func (lm *LargeMap) Get(name interface{}) (map[interface{}]interface{}, error) {
 	res, err := lm.client.Execute(lm.policy, lm.key, lm.packageName, "get", lm.binName, NewValue(name))
 

--- a/marshal.go
+++ b/marshal.go
@@ -44,9 +44,8 @@ func valueToInterface(f reflect.Value) interface{} {
 	case reflect.Struct:
 		if f.Type().PkgPath() == "time" && f.Type().Name() == "Time" {
 			return f.Interface().(time.Time).UTC().UnixNano()
-		} else {
-			return structToMap(f)
 		}
+		return structToMap(f)
 	case reflect.Bool:
 		if f.Bool() == true {
 			return int64(1)
@@ -95,9 +94,8 @@ func fieldAlias(f reflect.StructField) string {
 			return ""
 		}
 		return alias
-	} else {
-		return f.Name
 	}
+	return f.Name
 }
 
 func structToMap(s reflect.Value) map[string]interface{} {

--- a/operation.go
+++ b/operation.go
@@ -17,9 +17,12 @@ package aerospike
 // OperationType determines operation type
 type OperationType byte
 
+// Valid OperationType values that can be used to create custom Operations.
+// The names are self-explanatory.
 const (
 	READ OperationType = 1
 	// READ_HEADER OperationType = 1
+
 	WRITE   OperationType = 2
 	ADD     OperationType = 5
 	APPEND  OperationType = 9

--- a/role.go
+++ b/role.go
@@ -19,15 +19,15 @@ type Role string
 
 // Pre-defined user roles.
 const (
-	// Manage users their roles.
+	// UserAdmin allows to manages users and their roles.
 	UserAdmin Role = "user-admin"
 
-	// Manage indicies, user defined functions and server configuration.
+	// SysAdmin allows to manage indicies, user defined functions and server configuration.
 	SysAdmin Role = "sys-admin"
 
-	// Allow read and write transactions with the database.
+	// ReadWrite allows read and write transactions with the database.
 	ReadWrite Role = "read-write"
 
-	// Allow read transactions with the database.
+	// Read allow read transactions with the database.
 	Read Role = "Read"
 )

--- a/user_roles.go
+++ b/user_roles.go
@@ -15,11 +15,11 @@
 
 package aerospike
 
-// User and assigned roles.
+// UserRoles contains information about a user.
 type UserRoles struct {
 	// User name.
 	User string
 
-	// List of assigned roles.
+	// Roles is a list of assigned roles.
 	Roles []string
 }


### PR DESCRIPTION
*These changes do not modify any behavior.*

I noticed that golint was giving a lot of warnings/notices, so I took a few seconds to get rid of some of them. Most changes are correcting comment formats and removing of unrequired else blocks.

I'm ignoring some notices (`grep -v`). The first (dot import) is a lot of work to get rid of, and not that important to the user. The second (caps) and third (Id>ID) would require breaking changes.
These golint notices are now left:
```
$ golint | grep -v "should not use dot imports" | grep -v "don't use ALL_CAPS in Go names" | grep -v "Id should be"
admin_command.go:57:6: exported type AdminCommand should have comment or be unexported
marshal.go:157:6: exported type SyncMap should have comment or be unexported
recordset.go:23:6: exported type Result should have comment or be unexported
role.go:18:6: exported type Role should have comment or be unexported
value.go:61:6: type name will be used as aerospike.AerospikeBlob by other packages, and that stutters; consider calling this Blob
```