### PR TITLE
Fix *Connection.Read() total bytes count on error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -88,10 +88,11 @@ func (ctn *Connection) Read(buf []byte, length int) (total int, err error) {
 	// Don't worry about the loop; we've already set the timeout elsewhere
 	var r int
 	for total < length {
-		if r, err = ctn.conn.Read(buf[total:length]); err != nil {
+		r, err = ctn.conn.Read(buf[total:length])
+		total += r
+		if err != nil {
 			break
 		}
-		total += r
 	}
 
 	if err == nil && total == length {


### PR DESCRIPTION
I noticed that the total read bytes count returned `*Connection.Read()` could be off from the actual number of read bytes when an error occurred. In some cases a net.Conn can read bytes (n>0) while also returning with an error (for example: EOF).