### PR TITLE
Fix race condition on objectMappings map

### DIFF
--- a/read_command.go
+++ b/read_command.go
@@ -35,8 +35,6 @@ type readCommand struct {
 
 	// pointer to the object that's going to be unmarshalled
 	object interface{}
-	// mapping of aliases for the object fields
-	objectMappings map[string]map[string]string
 }
 
 func newReadCommand(cluster *Cluster, policy Policy, key *Key, binNames []string) *readCommand {
@@ -194,8 +192,6 @@ func (cmd *readCommand) parseObject(
 
 		// map tags
 		cacheObjectTags(rv)
-
-		cmd.objectMappings = objectMappings.objectMappings //getMapping(rv.Type().Name())
 	}
 
 	for i := 0; i < opCount; i++ {
@@ -232,7 +228,7 @@ func (cmd *readCommand) setObjectField(obj reflect.Value, fieldName string, valu
 
 	// find the name based on tag mapping
 	iobj := reflect.Indirect(obj)
-	if name, exists := cmd.objectMappings[iobj.Type().Name()][fieldName]; exists {
+	if name, exists := objectMappings.getMapping(iobj)[fieldName]; exists {
 		fieldName = name
 	}
 	f := iobj.FieldByName(fieldName)


### PR DESCRIPTION
I found and fixed a race condition.

The `readCommand` was storing a reference to the field `objectMappings` of the global var `objectMappings` (type `SyncMap`). It was using the reference for direct read access; thereby bypassing the SyncMap's getMapping method which adds a mutex lock/unlock around read/write operations on the map.

This fixes the race condition, but it comes with a cost (more mutex lock/unlock will occur). So you might not want to merge this in directly but instead first do a benchmark and/or improvements concerning performance.