### PR TITLE
cluster: Fix index out of range in removeNodesCopy

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -520,7 +520,12 @@ func (clstr *Cluster) removeNodesCopy(nodesToRemove []*Node) {
 	// and the tend goroutine is the only goroutine modifying nodes, we are guaranteed that nodes
 	// in nodesToRemove exist.  Therefore, we know the final array size.
 	nodes := clstr.GetNodes()
-	nodeArray := make([]*Node, len(nodes)-len(nodesToRemove))
+	nodeNum := len(nodes) - len(nodesToRemove)
+	if nodeNum <= 0 {
+		Logger.Warn("Node remove is zero or negative, will cause panic. Aborting.")
+		return
+	}
+	nodeArray := make([]*Node, nodeNum)
 	count := 0
 
 	// Add nodes that are not in remove list.


### PR DESCRIPTION
Ran into some issues where we would get an index out of range because
make() was given a length of zero.
Thus the first time nodeArray is accessed it threw an index out
of range panic.

It was only happening a few seconds after starting the cluster, so
there might be a bit more of an elegant solution but I have not had
time to take a deeper look into it.

Most recent stacktrace (using an older version of the library):

panic: runtime error: index out of range
goroutine 71 [running]:
github.com/aerospike/aerospike-client-go.(*Cluster).removeNodesCopy(0xc208
7d4080, 0xc2d2a6cee8, 0x1, 0x1)
/usr/go/src/github.com/aerospike/aerospike-client-go/cluster.go:528 +0x54d
github.com/aerospike/aerospike-client-go.(*Cluster).removeNodes(0xc2087d40
80, 0xc2d2a6cee8, 0x1, 0x1)
/usr/go/src/github.com/aerospike/aerospike-client-go/cluster.go:504 +0x256
github.com/aerospike/aerospike-client-go.(*Cluster).tend(0xc2087d4080, 0x0,
 0x0)
/usr/go/src/github.com/aerospike/aerospike-client-go/cluster.go:187 +0x413
github.com/aerospike/aerospike-client-go.(*Cluster).clusterBoss(0xc2087d4080)
/usr/go/src/github.com/aerospike/aerospike-client-go/cluster.go:110 +0x206
created by github.com/aerospike/aerospike-client-go.NewCluster
/usr/go/src/github.com/aerospike/aerospike-client-go/cluster.go:91 +0x3fd