### PR TITLE
Refactor tools/asinfo to be more idiomatic golang

### DIFF
--- a/tools/asinfo/asinfo.go
+++ b/tools/asinfo/asinfo.go
@@ -62,10 +62,20 @@ func main() {
 
 	node.PutConnection(conn)
 
+	outfmt := `%d :  %s;     %s;;`
+	if *sepLines {
+		outfmt = `%d :  %s\n     %s\n\n`
+	}
 	cnt := 1
 	for k, v := range infoMap {
-		log.Printf("%d :  %s\n     %s\n\n", cnt, k, v)
+		log.Printf(outfmt, cnt, k, v)
 		cnt++
+	}
+
+	if !*sepLines {
+		// Tack a newline on the end of output to be more
+		// terminal friendly if we haven't used them.
+		log.Println("")
 	}
 }
 


### PR DESCRIPTION
Keeping in line with the golang standard library, I removed the deeply-nested if/else calls and (since error handling was mostly if err -> die()) moved error handling out into a dieIfError function that optionally takes a series of callbacks .

I also noticed that sepLines wasn't actually implemented-- I threw that in as well, but I'm not entirely sure if the formatting is in line with the asinfo tool distributed with the aerospike tools package. Where this golang script works marvelously, the asinfo from the tools package just gives me `request to  %{host} : %{port}  returned error` on the same query. So I followed the help text here and just replaced newlines with semicolons.

Changing the number of semicolons per newline is bikeshedding incarnate, so just let me know which way that should go!