### PR TITLE
Reverted KeepConnection to only discard connection errors

### DIFF
--- a/types/result_code.go
+++ b/types/result_code.go
@@ -244,11 +244,24 @@ func KeepConnection(err error) bool {
 	}
 
 	switch ae.resultCode {
-	case KEY_NOT_FOUND_ERROR:
-		return true
+	case 0, // Zero Value
+		QUERY_TERMINATED,
+		SCAN_TERMINATED,
+		INVALID_NODE_ERROR,
+		PARSE_ERROR,
+		SERIALIZE_ERROR,
+		SERVER_MEM_ERROR,
+		TIMEOUT,
+		SERVER_NOT_AVAILABLE,
+		SCAN_ABORT,
+		INDEX_OOM,
+		QUERY_ABORTED,
+		QUERY_TIMEOUT:
+
+		return false
 
 	default:
-		return false
+		return true
 	}
 }
 


### PR DESCRIPTION
Not sure why this was changed however I would think you would want to only invalidate the connection on a connection error.