### PR TITLE
In case of LimitConnectionsToQueueSize is false, connectionCount is invalid

### DIFF
--- a/node.go
+++ b/node.go
@@ -442,8 +442,10 @@ func (nd *Node) getConnection(timeout time.Duration) (conn *Connection, err erro
 	}
 
 	if conn == nil {
+		cc := nd.connectionCount.IncrementAndGet()
+
 		// if connection count is limited and enough connections are already created, don't create a new one
-		if nd.cluster.clientPolicy.LimitConnectionsToQueueSize && nd.connectionCount.IncrementAndGet() > nd.cluster.clientPolicy.ConnectionQueueSize {
+		if nd.cluster.clientPolicy.LimitConnectionsToQueueSize && cc > nd.cluster.clientPolicy.ConnectionQueueSize {
 			nd.connectionCount.DecrementAndGet()
 			return nil, ErrConnectionPoolEmpty
 		}


### PR DESCRIPTION
Hi there.
It seems that `connectionCount` is always invalid value when `LimitConnectionsToQueueSize` is false.