### PR TITLE
Ignore hosts from other subnets

### DIFF
--- a/client_policy.go
+++ b/client_policy.go
@@ -86,6 +86,9 @@ type ClientPolicy struct {
 	// For better performance, we suggest prefering the server-side ciphers by
 	// setting PreferServerCipherSuites = true.
 	TlsConfig *tls.Config //= nil
+
+	// IgnoreOtherSubnetAliases helps to ignore aliases that are outside main subnet
+	IgnoreOtherSubnetAliases bool //= false
 }
 
 // NewClientPolicy generates a new ClientPolicy with default values.
@@ -98,6 +101,7 @@ func NewClientPolicy() *ClientPolicy {
 		TendInterval:                time.Second,
 		LimitConnectionsToQueueSize: true,
 		RequestProleReplicas:        false,
+		IgnoreOtherSubnetAliases:    false,
 	}
 }
 

--- a/node_validator.go
+++ b/node_validator.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"bytes"
 
 	. "github.com/aerospike/aerospike-client-go/logger"
 	. "github.com/aerospike/aerospike-client-go/types"
@@ -74,6 +75,22 @@ func (ndv *nodeValidator) seedNodes(cluster *Cluster, host *Host, nodesToAdd *no
 }
 
 func (ndv *nodeValidator) validateNode(cluster *Cluster, host *Host) error {
+	if cluster.clientPolicy.IgnoreOtherSubnetAliases {
+		masterHostname := cluster.GetNodes()[0].host.Name
+		ip, ipnet, err := net.ParseCIDR(masterHostname + "/24")
+		if err != nil {
+			Logger.Error(err.Error())
+			return NewAerospikeError(NO_AVAILABLE_CONNECTIONS_TO_NODE, "Failed parsing hostname...")
+		}
+
+		stop := ip.Mask(ipnet.Mask)
+		stop[3] += 255
+		if bytes.Compare(net.ParseIP(host.Name).To4(), ip.Mask(ipnet.Mask).To4()) >= 0 && bytes.Compare(net.ParseIP(host.Name).To4(), stop.To4()) < 0 {
+		} else {
+			return NewAerospikeError(NO_AVAILABLE_CONNECTIONS_TO_NODE, "Ignored hostname from other subnet...")
+		}
+	}
+
 	if err := ndv.setAliases(host); err != nil {
 		return err
 	}


### PR DESCRIPTION
Not common usecase. service.address set to 0.0.0.0 and some interfaces not visible beacuse of proxy or VPN. Initialising client takes forever.