### PR TITLE
Adds SleepMultiplier to BasePolicy for exponential backoff

### DIFF
--- a/command.go
+++ b/command.go
@@ -1232,6 +1232,9 @@ func (cmd *baseCommand) execute(ifc command) (err error) {
 	policy := ifc.getPolicy(ifc).GetBasePolicy()
 	iterations := -1
 
+	// for exponential backoff
+	interval := policy.SleepBetweenRetries
+
 	// set timeout outside the loop
 	deadline := time.Now().Add(policy.Timeout)
 
@@ -1244,7 +1247,8 @@ func (cmd *baseCommand) execute(ifc command) (err error) {
 
 		// Sleep before trying again, after the first iteration
 		if iterations > 0 && policy.SleepBetweenRetries > 0 {
-			time.Sleep(policy.SleepBetweenRetries)
+			time.Sleep(interval)
+			interval = time.Duration(float64(interval) * policy.SleepMultiplier)
 		}
 
 		// check for command timeout

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -24,6 +24,7 @@ When invoking an operation, you can choose:
     Timeout:             0 * time.Millisecond, // no timeout
     MaxRetries:          2,
     SleepBetweenRetries: 500 * time.Millisecond,
+    SleepMultiplier:     1.5
   }
 ```
 
@@ -58,7 +59,9 @@ Attributes:
                             * Default: `2`
 - `SleepBetweenRetries`     – Duration of waiting between retries.
                             * Default: `500 * time.Milliseconds`
-
+- `SleepMultiplier`         - The multiplying factor to be used for exponential
+                            backoff during retries.
+                            * Default: `1.0`
 
 <!--
 ################################################################################

--- a/policy.go
+++ b/policy.go
@@ -54,6 +54,10 @@ type BasePolicy struct {
 	// timeout was not exceeded.  Enter zero to skip sleep.
 	SleepBetweenRetries time.Duration //= 1ms;
 
+	// SleepMultiplier specifies the multiplying factor to be used for exponential backoff during retries.
+	// Default to (1.0).
+	SleepMultiplier float64 //= 1.0;
+
 	// ReplicaPolicy detemines the node to the send the read commands containing the key's partition replica type.
 	// Write commands are not affected by this setting, because all writes are directed
 	// to the node containing the key's master partition.
@@ -69,6 +73,7 @@ func NewPolicy() *BasePolicy {
 		Timeout:             0 * time.Millisecond,
 		MaxRetries:          2,
 		SleepBetweenRetries: 1 * time.Millisecond,
+		SleepMultiplier:     1.0,
 		ReplicaPolicy:       MASTER,
 	}
 }


### PR DESCRIPTION
Hi,

This PR adds a `SleepMultiplier` field to `BasePolicy`, which can be used to define the multiplying factor for exponential backoff during retries. See #177 for more information.

Please review and merge.

Thanks,
Venil