### PR TITLE
Add aerogo/aerospike to alternatives in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Please refer to [`CHANGELOG.md`](CHANGELOG.md) if you encounter breaking changes
 - [Tests](#Tests)
 - [Examples](#Examples)
   - [Tools](#Tools)
+- [Alternatives](#Alternatives)
 
 
 ## Usage:
@@ -150,6 +151,11 @@ See the [`tools/benchmark/README.md`](tools/benchmark/README.md) for details.
 ## API Documentation
 
 API documentation is available in the [`docs`](docs/README.md) directory.
+
+<a name="Alternatives"></a>
+## Alternatives
+
+* [aerogo/aerospike](https://github.com/aerogo/aerospike) A slightly more high-level API built on top of this package.
 
 ## License
 


### PR DESCRIPTION
I'm not sure if the Aerospike team wants to list derived work on their README but I've added this PR in case you don't mind it.