### PR TITLE
Sometimes finalizer for closing cluster happens panic

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -245,8 +245,6 @@ Loop:
 	}
 
 	// cleanup code goes here
-	clstr.closed.Set(true)
-
 	// close the nodes
 	nodeArray := clstr.GetNodes()
 	for _, node := range nodeArray {
@@ -952,7 +950,7 @@ func (clstr *Cluster) findNodeByName(nodeName string) *Node {
 // Close closes all cached connections to the cluster nodes
 // and stops the tend goroutine.
 func (clstr *Cluster) Close() {
-	if !clstr.closed.Get() {
+	if clstr.closed.CompareAndToggle(false) {
 		// send close signal to maintenance channel
 		close(clstr.tendChannel)
 


### PR DESCRIPTION
Hi, @khaf .

Client version: v1.27.0 (1dc8cf203d24cd454e71ce40ab4cd0bf3112df90).
Server version: Aerospike Server CE :3.14.0

Sometimes happens panic occasionally when the Close function is called multiple times in parallel.
It seems that closing `tendChannel` is called twice.

Sample code is here:
```go
func main() {
	client, err := aerospike.NewClient("127.0.0.1", 3000)
	panicOnError(err)
        defer client.Close()
        Task(client)
        // end
}
```

Traceback is here: (file path is simplified)
```
panic: close of closed channel
goroutine 4 [running]:
vendor/github.com/aerospike/aerospike-client-go.(*Cluster).Close(0xc42007afc0)
vendor/github.com/aerospike/aerospike-client-go/cluster.go:898 +0x5c
vendor/github.com/aerospike/aerospike-client-go.(*Client).Close(0xc42036b410)
vendor/github.com/aerospike/aerospike-client-go/client.go:109 +0x2e
vendor/github.com/aerospike/aerospike-client-go.clientFinalizer(0xc42036b410)
vendor/github.com/aerospike/aerospike-client-go/client.go:54 +0x2b
```