### PR TITLE
Add ClientPolicy.TendTimeout

### DIFF
--- a/client_policy.go
+++ b/client_policy.go
@@ -58,6 +58,10 @@ type ClientPolicy struct {
 	// Minimum possible interval is 10 Milliseconds.
 	TendInterval time.Duration //= 1 second
 
+	// Initial cluster connection timeout duration.
+	// The timeout when connecting to the cluster for the first time.
+	TendTimeout time.Duration //= 30 seconds
+
 	// A IP translation table is used in cases where different clients
 	// use different server IP addresses.  This may be necessary when
 	// using clients from both inside and outside a local area
@@ -95,6 +99,7 @@ type ClientPolicy struct {
 func NewClientPolicy() *ClientPolicy {
 	return &ClientPolicy{
 		Timeout:                     30 * time.Second,
+		TendTimeout:                 30 * time.Second,
 		IdleTimeout:                 defaultIdleTimeout,
 		ConnectionQueueSize:         256,
 		FailIfNotConnected:          true,

--- a/cluster.go
+++ b/cluster.go
@@ -533,7 +533,7 @@ func (clstr *Cluster) waitTillStabilized() error {
 	}()
 
 	select {
-	case <-time.After(clstr.clientPolicy.Timeout):
+	case <-time.After(clstr.clientPolicy.TendTimeout):
 		return errors.New("Connecting to the cluster timed out.")
 	case err := <-doneCh:
 		return err
@@ -608,7 +608,7 @@ L:
 		case <-successChan:
 			// even one seed is enough
 			return true, nil
-		case <-time.After(clstr.clientPolicy.Timeout):
+		case <-time.After(clstr.clientPolicy.TendTimeout):
 			// time is up, no seeds found
 			wg.Wait()
 			break L


### PR DESCRIPTION
`ClientPolicy.Timeout` is used not only as deadline for `net.Conn` but also as deadline for a lot complex network operations in `waitTillStabilized` function. Thus connecting to the large cluster is often timed out when using, for example, 100ms in `ClientPolicy.Timeout`.