### PR TITLE
fixing default RecordQueueSize in documentation

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -111,7 +111,7 @@ Includes All Base Policy attributes, plus:
                            * Default: `0` All nodes.
 - `RecordQueueSize`       – Number of records to place in queue before blocking.
   Records received from multiple server nodes will be placed in a queue. A separate goroutine consumes these records in parallel. If the queue is full, the producer goroutines will block until records are consumed.
-                           * Default: `5000`
+                           * Default: `50`
 
 <!--
 ################################################################################

--- a/multi_policy.go
+++ b/multi_policy.go
@@ -32,7 +32,7 @@ type MultiPolicy struct {
 	// Records received from multiple server nodes will be placed in a queue.
 	// A separate goroutine consumes these records in parallel.
 	// If the queue is full, the producer goroutines will block until records are consumed.
-	RecordQueueSize int //= 5000
+	RecordQueueSize int //= 50
 
 	// Indicates if bin data is retrieved. If false, only record digests are retrieved.
 	IncludeBinData bool //= true;


### PR DESCRIPTION
Hi, 

This fixes the default RecordQueueSize listed in the scan policy documentation, which currently says its value is 5000, but the code uses 50.

dave