### PR TITLE
Don't send racks: command if clientPolicy.RackAware is not set

### DIFF
--- a/node.go
+++ b/node.go
@@ -124,7 +124,12 @@ func (nd *Node) Refresh(peers *peers) error {
 	var infoMap map[string]string
 	var err error
 	if peers.usePeers.Get() {
-		infoMap, err = nd.RequestInfo(&nd.cluster.infoPolicy, "node", "peers-generation", "partition-generation", "racks:")
+		commands := []string{"node", "peers-generation", "partition-generation"}
+		if nd.cluster.clientPolicy.RackAware {
+			commands = append(commands, "racks:")
+		}
+
+		infoMap, err = nd.RequestInfo(&nd.cluster.infoPolicy, commands...)
 		if err != nil {
 			nd.refreshFailed(err)
 			return err
@@ -145,7 +150,10 @@ func (nd *Node) Refresh(peers *peers) error {
 			return err
 		}
 	} else {
-		commands := []string{"node", "partition-generation", "racks:", nd.cluster.clientPolicy.servicesString()}
+		commands := []string{"node", "partition-generation", nd.cluster.clientPolicy.servicesString()}
+		if nd.cluster.clientPolicy.RackAware {
+			commands = append(commands, "racks:")
+		}
 
 		infoMap, err = nd.RequestInfo(&nd.cluster.infoPolicy, commands...)
 		if err != nil {


### PR DESCRIPTION
Hi,

this change updates `Node#Refresh` function to send `racks:` command based on `clientPolicy.RackAware` flag. There are two reasons behind it:

1. `racks:` won't be sent to older versions of `Aerospike` which don't support it. This will remove `received command racks, not registered` message from the log which is getting spammed by it otherwise.
2. `updateRackInfo` function [checks the state of the flag](https://github.com/aerospike/aerospike-client-go/blob/master/node.go#L232-L234) as well and doesn't use result of the command if it is not set.