### PR TITLE
GetObject slices bug: assign result of the append

### DIFF
--- a/read_command_reflect.go
+++ b/read_command_reflect.go
@@ -343,7 +343,7 @@ func setValue(f reflect.Value, value interface{}, supportsFloat bool) error {
 					f.Set(reflect.MakeSlice(reflect.SliceOf(f.Type().Elem()), theArray.Len(), theArray.Len()))
 				} else if f.Len() < theArray.Len() {
 					count := theArray.Len() - f.Len()
-					f = reflect.AppendSlice(f, reflect.MakeSlice(reflect.SliceOf(f.Type().Elem()), count, count))
+					f.Set(reflect.AppendSlice(f, reflect.MakeSlice(reflect.SliceOf(f.Type().Elem()), count, count)))
 				}
 			}
 


### PR DESCRIPTION
There is currently a bug happening when using `GetObject()`. See the following pseudo-code:

```go
type MyObject struct {
    List []string
}

func testcase() {
    var o1, o2 MyObject
    o1.List = nil // the default is nil anyways
    o2.List = []string{}

    client.GetObject(nil, key, &o1)
    client.GetObject(nil, key, &o2)

    if len(o1.List) != len(o2.List) {
         panic("BUG: slice was not set properly")
    }
}
```

With the change proposed here the bug is fixed (the slice gets assigned); the assignment `f = ` there is currently doing nothing.

There do not seem to be unit tests for this function, otherwise I would have added a regression test; perhaps I can contribute something on a separate PR.