### PR TITLE
v6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change History
 
+## December 5 2022: v6.7.0
+
+  This is a minor improvement and fix release.
+
+  * **Improvements**
+
+    - Improves testing for float64 precision formatting between amd64 and aarch64.
+
+  * **Fixes**
+
+    - [CLIENT-2019] Write Batch operation with an invalid namespace record causes all batch transactions to fail.
+    - [CLIENT-2020] Support `QueryPartitions` with non-nil filter (secondary index query)
+
 ## November 8 2022: v6.6.0
 
   This is a minor improvement and fix release.

--- a/batch_node_list.go
+++ b/batch_node_list.go
@@ -276,8 +276,10 @@ func newBatchOperateNodeListIfc(cluster *Cluster, policy *BatchPolicy, records [
 		}
 
 		if err != nil {
+			records[i].chainError(err)
+			records[i].setError(err.resultCode(), false)
 			errs = chainErrors(err, errs)
-			// return nil, err
+			continue
 		}
 
 		if batchNode := findBatchNode(batchNodes, node); batchNode == nil {

--- a/client.go
+++ b/client.go
@@ -542,7 +542,7 @@ func (clnt *Client) BatchOperate(policy *BatchPolicy, records []BatchRecordIfc) 
 	policy = clnt.getUsableBatchPolicy(policy)
 
 	batchNodes, err := newBatchOperateNodeListIfc(clnt.cluster, policy, records)
-	if err != nil {
+	if err != nil && policy.RespondAllKeys {
 		return err
 	}
 

--- a/client.go
+++ b/client.go
@@ -1024,10 +1024,6 @@ func parseIndexErrorCode(response string) types.ResultCode {
 // This method is only supported by Aerospike 4.9+ servers.
 // If the policy is nil, the default relevant policy will be used.
 func (clnt *Client) QueryPartitions(policy *QueryPolicy, statement *Statement, partitionFilter *PartitionFilter) (*Recordset, Error) {
-	if statement.Filter != nil {
-		return nil, ErrPartitionScanQueryNotSupported.err()
-	}
-
 	policy = clnt.getUsableQueryPolicy(policy)
 	nodes := clnt.cluster.GetNodes()
 	if len(nodes) == 0 {

--- a/client_object_test.go
+++ b/client_object_test.go
@@ -1123,7 +1123,7 @@ var _ = gg.Describe("Aerospike", func() {
 						gm.Expect(err).ToNot(gm.HaveOccurred())
 
 						gm.Expect(t.Test).To(gm.Equal(float64(i)))
-						gm.Expect(t.TestLua).To(gm.Equal(testLua))
+						gm.Expect(t.TestLua).To(gm.BeNumerically("~", testLua))
 					}
 
 				}) // it

--- a/multi_command.go
+++ b/multi_command.go
@@ -218,7 +218,7 @@ func (cmd *baseMultiCommand) parseKey(fieldCount int, bval *int64) (*Key, Error)
 				return nil, err
 			}
 		case BVAL_ARRAY:
-			*bval = Buffer.LittleBytesToInt64(cmd.dataBuffer, cmd.dataOffset)
+			*bval = Buffer.LittleBytesToInt64(cmd.dataBuffer, 1)
 		}
 	}
 

--- a/query_executor.go
+++ b/query_executor.go
@@ -43,14 +43,13 @@ func (clnt *Client) queryPartitions(policy *QueryPolicy, tracker *partitionTrack
 			cmd := newQueryPartitionCommand(policy, tracker, nodePartition, statement, recordset)
 			weg.execute(cmd)
 		}
-		// no need to manage the errors; they are send back via the recordset
-		weg.wait()
+		errs = chainErrors(weg.wait(), errs)
 
 		done, err := tracker.isComplete(clnt.Cluster(), &policy.BasePolicy)
 		if done || err != nil {
+			errs = chainErrors(err, errs)
 			// Query is complete.
-			if err != nil {
-				errs = chainErrors(err, errs)
+			if errs != nil {
 				recordset.sendError(errs)
 			}
 			return

--- a/scan_executor.go
+++ b/scan_executor.go
@@ -43,13 +43,12 @@ func (clnt *Client) scanPartitions(policy *ScanPolicy, tracker *partitionTracker
 			cmd := newScanPartitionCommand(policy, tracker, nodePartition, namespace, setName, binNames, recordset)
 			weg.execute(cmd)
 		}
-		// no need to manage the errors; they are send back via the recordset
-		weg.wait()
+		errs = chainErrors(weg.wait(), errs)
 
 		if done, err := tracker.isComplete(clnt.Cluster(), &policy.BasePolicy); done || err != nil {
+			errs = chainErrors(err, errs)
 			// Scan is complete.
-			if err != nil {
-				errs = chainErrors(err, errs)
+			if errs != nil {
 				recordset.sendError(errs)
 			}
 			return


### PR DESCRIPTION
  This is a minor improvement and fix release.

  * **Improvements**

    - Improves testing for float64 precision formatting between amd64 and aarch64.

  * **Fixes**

    - [CLIENT-2019] Write Batch operation with an invalid namespace record causes all batch transactions to fail.
    - [CLIENT-2020] Support `QueryPartitions` with non-nil filter (secondary index query)


[CLIENT-2019]: https://aerospike.atlassian.net/browse/CLIENT-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-2020]: https://aerospike.atlassian.net/browse/CLIENT-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ