### PR TITLE
chore: deprecate io/ioutil

### DIFF
--- a/aerospike_suite_test.go
+++ b/aerospike_suite_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -380,7 +379,7 @@ func initTLS() *tls.Config {
 
 // Read content from file
 func readFromFile(filePath string) ([]byte, error) {
-	dataBytes, err := ioutil.ReadFile(filePath)
+	dataBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read from file `%s`: `%v`", filePath, err)
 	}

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -786,7 +786,7 @@ func (clnt *Client) ScanNode(apolicy *ScanPolicy, node *Node, namespace string, 
 // If the policy is nil, the default relevant policy will be used.
 func (clnt *Client) RegisterUDFFromFile(policy *WritePolicy, clientPath string, serverPath string, language Language) (*RegisterTask, Error) {
 	policy = clnt.getUsableWritePolicy(policy)
-	udfBody, err := ioutil.ReadFile(clientPath)
+	udfBody, err := os.ReadFile(clientPath)
 	if err != nil {
 		return nil, newCommonError(err)
 	}

--- a/examples/tls_secure_connection/tls_secure_connection.go
+++ b/examples/tls_secure_connection/tls_secure_connection.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func readCertificates(serverCertDir string, clientCertFile, clientKeyFile string
 		// Adding server certificates to the pool.
 		// These certificates are used to verify the identity of the server nodes to the client.
 		for _, caFile := range serverCerts {
-			caCert, err := ioutil.ReadFile(caFile)
+			caCert, err := os.ReadFile(caFile)
 			if err != nil {
 				log.Fatalf("FAILED: Adding server certificate %s to the pool failed: %s", caFile, err)
 			}


### PR DESCRIPTION
*Description*: Deprecate the `io/ioutil` pkg

*Breaking*: No

*Scope*: Only at places where `io/iotuil` was being used

*Tested*: Yes