### PR TITLE
Resolve memory leak caused by circular reference in client finalizer

### DIFF
--- a/batch_command.go
+++ b/batch_command.go
@@ -28,12 +28,18 @@ type batcher interface {
 	generateBatchNodes(*Cluster) ([]*batchNode, Error)
 	setSequence(int, int)
 
-	executeSingle(*Client) Error
+	executeSingle(clientIfc) Error
+}
+
+type clientIfc interface {
+	ClientIfc
+	execute(policy *WritePolicy, key *Key, packageName string, functionName string, args ...Value) (*Record, Error)
 }
 
 type batchCommand struct {
 	baseMultiCommand
 
+	client     clientIfc
 	batch      *batchNode
 	policy     *BatchPolicy
 	sequenceAP int

--- a/batch_command_get.go
+++ b/batch_command_get.go
@@ -55,7 +55,7 @@ var batchObjectParser func(
 ) Error
 
 func newBatchCommandGet(
-	node *Node,
+	client clientIfc,
 	batch *batchNode,
 	policy *BatchPolicy,
 	keys []*Key,
@@ -65,8 +65,14 @@ func newBatchCommandGet(
 	readAttr int,
 	isOperation bool,
 ) *batchCommandGet {
+	var node *Node
+	if batch != nil {
+		node = batch.Node
+	}
+
 	res := &batchCommandGet{
 		batchCommand: batchCommand{
+			client:           client,
 			baseMultiCommand: *newMultiCommand(node, nil, isOperation),
 			policy:           policy,
 			batch:            batch,
@@ -158,7 +164,6 @@ func (cmd *batchCommandGet) parseRecordResults(ifc command, receiveSize int) (bo
 					cmd.objectsFound[batchIndex] = true
 					if err := batchObjectParser(cmd, batchIndex, opCount, fieldCount, generation, expiration); err != nil {
 						return false, err
-
 					}
 				}
 			}
@@ -216,7 +221,7 @@ func (cmd *batchCommandGet) transactionType() transactionType {
 	return ttBatchRead
 }
 
-func (cmd *batchCommandGet) executeSingle(client *Client) Error {
+func (cmd *batchCommandGet) executeSingle(client clientIfc) Error {
 	for _, offset := range cmd.batch.offsets {
 		var err Error
 		if len(cmd.ops) > 0 {
@@ -254,7 +259,7 @@ func (cmd *batchCommandGet) executeSingle(client *Client) Error {
 
 func (cmd *batchCommandGet) Execute() Error {
 	if cmd.objects == nil && len(cmd.batch.offsets) == 1 {
-		return cmd.executeSingle(cmd.node.cluster.client)
+		return cmd.executeSingle(cmd.client)
 	}
 	return cmd.execute(cmd)
 }

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -21,6 +21,7 @@ type batchIndexCommandGet struct {
 }
 
 func newBatchIndexCommandGet(
+	client clientIfc,
 	batch *batchNode,
 	policy *BatchPolicy,
 	records []*BatchRead,
@@ -34,6 +35,7 @@ func newBatchIndexCommandGet(
 	res := &batchIndexCommandGet{
 		batchCommandGet{
 			batchCommand: batchCommand{
+				client:           client,
 				baseMultiCommand: *newMultiCommand(node, nil, isOperation),
 				policy:           policy,
 				batch:            batch,
@@ -59,12 +61,12 @@ func (cmd *batchIndexCommandGet) writeBuffer(ifc command) Error {
 
 func (cmd *batchIndexCommandGet) Execute() Error {
 	if len(cmd.batch.offsets) == 1 {
-		return cmd.executeSingle(cmd.node.cluster.client)
+		return cmd.executeSingle(cmd.client)
 	}
 	return cmd.execute(cmd)
 }
 
-func (cmd *batchIndexCommandGet) executeSingle(client *Client) Error {
+func (cmd *batchIndexCommandGet) executeSingle(client clientIfc) Error {
 	for i, br := range cmd.indexRecords {
 		var ops []*Operation
 		if br.headerOnly() {

--- a/client.go
+++ b/client.go
@@ -111,12 +111,8 @@ func NewClientWithPolicyAndHost(policy *ClientPolicy, hosts ...*Host) (*Client, 
 		DefaultInfoPolicy:        NewInfoPolicy(),
 	}
 
-	// back reference especially used in batch commands
-	cluster.client = client
-
 	runtime.SetFinalizer(client, clientFinalizer)
 	return client, err
-
 }
 
 //-------------------------------------------------------
@@ -453,7 +449,7 @@ func (clnt *Client) BatchExists(policy *BatchPolicy, keys []*Key) ([]bool, Error
 	}
 
 	// pass nil to make sure it will be cloned and prepared
-	cmd := newBatchCommandExists(nil, nil, policy, keys, existsArray)
+	cmd := newBatchCommandExists(clnt, nil, policy, keys, existsArray)
 	filteredOut, err := clnt.batchExecute(policy, batchNodes, cmd)
 	if filteredOut > 0 {
 		err = chainErrors(ErrFilteredOut.err(), err)
@@ -526,7 +522,7 @@ func (clnt *Client) BatchGet(policy *BatchPolicy, keys []*Key, binNames ...strin
 		return nil, err
 	}
 
-	cmd := newBatchCommandGet(nil, nil, policy, keys, binNames, nil, records, _INFO1_READ, false)
+	cmd := newBatchCommandGet(clnt, nil, policy, keys, binNames, nil, records, _INFO1_READ, false)
 	filteredOut, err := clnt.batchExecute(policy, batchNodes, cmd)
 	if err != nil && !policy.AllowPartialResults {
 		return nil, err
@@ -556,7 +552,7 @@ func (clnt *Client) BatchGetOperate(policy *BatchPolicy, keys []*Key, ops ...*Op
 		return nil, err
 	}
 
-	cmd := newBatchCommandGet(nil, nil, policy, keys, nil, ops, records, _INFO1_READ, true)
+	cmd := newBatchCommandGet(clnt, nil, policy, keys, nil, ops, records, _INFO1_READ, true)
 	filteredOut, err := clnt.batchExecute(policy, batchNodes, cmd)
 	if err != nil && !policy.AllowPartialResults {
 		return nil, err
@@ -578,7 +574,7 @@ func (clnt *Client) BatchGetOperate(policy *BatchPolicy, keys []*Key, ops ...*Op
 func (clnt *Client) BatchGetComplex(policy *BatchPolicy, records []*BatchRead) Error {
 	policy = clnt.getUsableBatchPolicy(policy)
 
-	cmd := newBatchIndexCommandGet(nil, policy, records, true)
+	cmd := newBatchIndexCommandGet(clnt, nil, policy, records, true)
 
 	batchNodes, err := newBatchIndexNodeList(clnt.cluster, policy, records)
 	if err != nil {
@@ -614,7 +610,7 @@ func (clnt *Client) BatchGetHeader(policy *BatchPolicy, keys []*Key) ([]*Record,
 		return nil, err
 	}
 
-	cmd := newBatchCommandGet(nil, nil, policy, keys, nil, nil, records, _INFO1_READ|_INFO1_NOBINDATA, false)
+	cmd := newBatchCommandGet(clnt, nil, policy, keys, nil, nil, records, _INFO1_READ|_INFO1_NOBINDATA, false)
 	filteredOut, err := clnt.batchExecute(policy, batchNodes, cmd)
 	if err != nil && !policy.AllowPartialResults {
 		return nil, err
@@ -650,7 +646,7 @@ func (clnt *Client) BatchDelete(policy *BatchPolicy, deletePolicy *BatchDeletePo
 		return nil, err
 	}
 
-	cmd := newBatchCommandDelete(nil, nil, policy, deletePolicy, keys, records, attr)
+	cmd := newBatchCommandDelete(clnt, nil, policy, deletePolicy, keys, records, attr)
 	_, err = clnt.batchExecute(policy, batchNodes, cmd)
 	return records, err
 }
@@ -670,7 +666,7 @@ func (clnt *Client) BatchOperate(policy *BatchPolicy, records []BatchRecordIfc) 
 		return err
 	}
 
-	cmd := newBatchCommandOperate(clnt, nil, nil, policy, records)
+	cmd := newBatchCommandOperate(clnt, nil, policy, records)
 	_, err = clnt.batchExecute(policy, batchNodes, cmd)
 	return err
 }
@@ -701,7 +697,7 @@ func (clnt *Client) BatchExecute(policy *BatchPolicy, udfPolicy *BatchUDFPolicy,
 		return nil, err
 	}
 
-	cmd := newBatchCommandUDF(nil, nil, policy, udfPolicy, keys, packageName, functionName, args, records, attr)
+	cmd := newBatchCommandUDF(clnt, nil, policy, udfPolicy, keys, packageName, functionName, args, records, attr)
 	_, err = clnt.batchExecute(policy, batchNodes, cmd)
 	return records, err
 }

--- a/client_reflect.go
+++ b/client_reflect.go
@@ -128,7 +128,7 @@ func (clnt *Client) BatchGetObjects(policy *BatchPolicy, keys []*Key, objects []
 	}
 
 	objectsFound := make([]bool, len(keys))
-	cmd := newBatchCommandGet(nil, nil, policy, keys, binNames, nil, nil, _INFO1_READ, false)
+	cmd := newBatchCommandGet(clnt, nil, policy, keys, binNames, nil, nil, _INFO1_READ, false)
 	cmd.objects = objectsVal
 	cmd.objectsFound = objectsFound
 

--- a/cluster.go
+++ b/cluster.go
@@ -32,8 +32,6 @@ import (
 // Cluster encapsulates the aerospike cluster nodes and manages
 // them.
 type Cluster struct {
-	client *Client
-
 	// Initial host nodes specified by user.
 	seeds iatomic.SyncVal //[]*Host
 

--- a/proxy_client.go
+++ b/proxy_client.go
@@ -723,7 +723,7 @@ func (clnt *ProxyClient) batchOperate(policy *BatchPolicy, records []BatchRecord
 		return 0, err
 	}
 
-	cmd := newBatchCommandOperate(clnt, nil, batchNode, policy, records)
+	cmd := newBatchCommandOperate(clnt, batchNode, policy, records)
 	return cmd.filteredOutCnt, cmd.ExecuteGRPC(clnt)
 }
 
@@ -900,7 +900,12 @@ func (clnt *ProxyClient) Execute(policy *WritePolicy, key *Key, packageName stri
 	if rec := command.GetRecord(); rec != nil && rec.Bins != nil {
 		return rec.Bins["SUCCESS"], nil
 	}
+
 	return nil, nil
+}
+
+func (clnt *ProxyClient) execute(policy *WritePolicy, key *Key, packageName string, functionName string, args ...Value) (*Record, Error) {
+	return nil, newError(types.UNSUPPORTED_FEATURE)
 }
 
 //----------------------------------------------------------

--- a/proxy_client_reflect.go
+++ b/proxy_client_reflect.go
@@ -121,7 +121,7 @@ func (clnt *ProxyClient) BatchGetObjects(policy *BatchPolicy, keys []*Key, objec
 		return nil, err
 	}
 
-	cmd := newBatchCommandOperate(clnt, nil, batchNode, policy, batchRecordsIfc)
+	cmd := newBatchCommandOperate(clnt, batchNode, policy, batchRecordsIfc)
 
 	objectsFound := make([]bool, len(keys))
 	cmd.objects = objectsVal
@@ -133,7 +133,6 @@ func (clnt *ProxyClient) BatchGetObjects(policy *BatchPolicy, keys []*Key, objec
 	// }
 
 	return objectsFound, err
-
 }
 
 // ScanPartitionObjects Reads records in specified namespace, set and partition filter.


### PR DESCRIPTION
A [circular reference](https://github.com/aerospike/aerospike-client-go/blob/v7.5.0/client.go#L115) between the client object and the cluster object prevents the [client's finalizer](https://github.com/aerospike/aerospike-client-go/blob/v7.5.0/client.go#L117) from executing, resulting in a memory leak. The issue can be reproduced by creating and closing multiple client instances in a loop.
To resolve this, the client instance has been injected into the batch commands directly.