### PR TITLE
Go Client v7.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Dockerfile*
 docker-compose.yml
 golangci.yml
 cover*.out
+.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change History
 
+## September 13 2024: v7.7.0
+
+  Minor improvement release.
+
+- **Improvements**
+  - [CLIENT-3112] Correctly handle new error messages/error codes returned by AS 7.2.
+  - [CLIENT-3102] Add "XDR key busy" error code 32.
+  - [CLIENT-3119] Use Generics For a General Code Clean Up
+    Uses several new generic containers to simplify concurrent access in the client.
+    Uses a Guard as a monitor for the tend connection. This encapsulates synchronized tend connection management using said Guard.
+  - Add documentation about client.WarmUp to the client initialization API.
+
+- **Fixes**
+  - [CLIENT-3082] BatchGet with empty Keys raises gRPC EOF error.
+
 ## August 12 2024: v7.6.1
 
   Minor improvement release.

--- a/client.go
+++ b/client.go
@@ -72,12 +72,22 @@ func clientFinalizer(f *Client) {
 //-------------------------------------------------------
 
 // NewClient generates a new Client instance.
+// The connection pool after connecting to the database is initially empty,
+// and connections are established on a per need basis, which can be slow and
+// time out some initial commands.
+// It is recommended to call the client.WarmUp() method right after connecting to the database
+// to fill up the connection pool to the required service level.
 func NewClient(hostname string, port int) (*Client, Error) {
 	return NewClientWithPolicyAndHost(NewClientPolicy(), NewHost(hostname, port))
 }
 
 // NewClientWithPolicy generates a new Client using the specified ClientPolicy.
 // If the policy is nil, the default relevant policy will be used.
+// The connection pool after connecting to the database is initially empty,
+// and connections are established on a per need basis, which can be slow and
+// time out some initial commands.
+// It is recommended to call the client.WarmUp() method right after connecting to the database
+// to fill up the connection pool to the required service level.
 func NewClientWithPolicy(policy *ClientPolicy, hostname string, port int) (*Client, Error) {
 	return NewClientWithPolicyAndHost(policy, NewHost(hostname, port))
 }
@@ -85,6 +95,11 @@ func NewClientWithPolicy(policy *ClientPolicy, hostname string, port int) (*Clie
 // NewClientWithPolicyAndHost generates a new Client with the specified ClientPolicy and
 // sets up the cluster using the provided hosts.
 // If the policy is nil, the default relevant policy will be used.
+// The connection pool after connecting to the database is initially empty,
+// and connections are established on a per need basis, which can be slow and
+// time out some initial commands.
+// It is recommended to call the client.WarmUp() method right after connecting to the database
+// to fill up the connection pool to the required service level.
 func NewClientWithPolicyAndHost(policy *ClientPolicy, hosts ...*Host) (*Client, Error) {
 	if policy == nil {
 		policy = NewClientPolicy()

--- a/client_test.go
+++ b/client_test.go
@@ -63,9 +63,9 @@ var _ = gg.Describe("Aerospike", func() {
 
 	var actualClusterName string
 
-	gg.Describe("Client IndexErrorParser", func() {
+	gg.Describe("Client InfoErrorParser", func() {
 
-		gg.It("must parse IndexError response strings", func() {
+		gg.It("must parse InfoError response strings", func() {
 			type t struct {
 				r    string
 				code types.ResultCode
@@ -73,7 +73,7 @@ var _ = gg.Describe("Aerospike", func() {
 			}
 
 			responses := []t{
-				{"invalid", types.PARSE_ERROR, "invalid"},
+				{"invalid", types.SERVER_ERROR, "invalid"},
 				{"FAIL", types.SERVER_ERROR, "FAIL"},
 				{"FAiL", types.SERVER_ERROR, "FAiL"},
 				{"Error", types.SERVER_ERROR, "Error"},
@@ -83,10 +83,12 @@ var _ = gg.Describe("Aerospike", func() {
 				{"ERROR:200", types.INDEX_FOUND, "Index already exists"},
 				{"FAIL:201", types.INDEX_NOTFOUND, "Index not found"},
 				{"FAIL:201:some message from the server", types.INDEX_NOTFOUND, "some message from the server"},
+				{"FAIL:some message from the server", types.SERVER_ERROR, "some message from the server"},
+				{"error:some message from the server", types.SERVER_ERROR, "some message from the server"},
 			}
 
 			for _, r := range responses {
-				err := as.ParseIndexErrorCode(r.r)
+				err := as.ParseInfoErrorCode(r.r)
 				gm.Expect(err).To(gm.HaveOccurred())
 				gm.Expect(err.(*as.AerospikeError).Msg()).To(gm.Equal(r.err))
 				gm.Expect(err.Matches(r.code)).To(gm.BeTrue())

--- a/cluster.go
+++ b/cluster.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	iatomic "github.com/aerospike/aerospike-client-go/v7/internal/atomic"
+	sm "github.com/aerospike/aerospike-client-go/v7/internal/atomic/map"
 	"github.com/aerospike/aerospike-client-go/v7/internal/seq"
 	"github.com/aerospike/aerospike-client-go/v7/logger"
 	"github.com/aerospike/aerospike-client-go/v7/types"
@@ -34,27 +35,27 @@ import (
 // them.
 type Cluster struct {
 	// Initial host nodes specified by user.
-	seeds iatomic.SyncVal //[]*Host
+	seeds iatomic.SyncVal[[]*Host]
 
 	// All aliases for all nodes in cluster.
 	// Only accessed within cluster tend goroutine.
-	aliases iatomic.SyncVal //map[Host]*Node
+	aliases sm.Map[Host, *Node]
 
 	// Map of active nodes in cluster.
 	// Only accessed within cluster tend goroutine.
-	nodesMap iatomic.SyncVal //map[string]*Node
+	nodesMap sm.Map[string, *Node]
 
 	// Active nodes in cluster.
-	nodes     iatomic.SyncVal       //[]*Node
+	nodes     iatomic.SyncVal[[]*Node]
 	stats     map[string]*nodeStats //host => stats
 	statsLock sync.Mutex
 
 	// enable performance metrics
-	metricsEnabled atomic.Bool  // bool
-	metricsPolicy  atomic.Value // *MetricsPolicy
+	metricsEnabled atomic.Bool // bool
+	metricsPolicy  iatomic.TypedVal[*MetricsPolicy]
 
 	// Hints for best node for a partition
-	partitionWriteMap atomic.Value //partitionMap
+	partitionWriteMap iatomic.TypedVal[partitionMap] //partitionMap
 
 	clientPolicy        ClientPolicy
 	infoPolicy          InfoPolicy
@@ -77,7 +78,7 @@ type Cluster struct {
 	user string
 
 	// Password in hashed format in bytes.
-	password iatomic.SyncVal // []byte
+	password iatomic.SyncVal[[]byte]
 }
 
 // NewCluster generates a Cluster instance.
@@ -119,17 +120,17 @@ func NewCluster(policy *ClientPolicy, hosts []*Host) (*Cluster, Error) {
 		tendChannel:  make(chan struct{}),
 
 		seeds:    *iatomic.NewSyncVal(hosts),
-		aliases:  *iatomic.NewSyncVal(make(map[Host]*Node)),
-		nodesMap: *iatomic.NewSyncVal(make(map[string]*Node)),
+		aliases:  *sm.New[Host, *Node](16),
+		nodesMap: *sm.New[string, *Node](16),
 		nodes:    *iatomic.NewSyncVal([]*Node{}),
 		stats:    map[string]*nodeStats{},
 
-		password: *iatomic.NewSyncVal(nil),
+		password: *iatomic.NewSyncVal[[]byte](nil),
 
 		supportsPartitionQuery: *iatomic.NewBool(false),
 	}
 
-	newCluster.partitionWriteMap.Store(make(partitionMap))
+	newCluster.partitionWriteMap.Set(make(partitionMap))
 
 	// setup auth info for cluster
 	if policy.RequiresAuthentication() {
@@ -225,8 +226,7 @@ Loop:
 // AddSeeds adds new hosts to the cluster.
 // They will be added to the cluster on next tend call.
 func (clstr *Cluster) AddSeeds(hosts []*Host) {
-	clstr.seeds.Update(func(val interface{}) (interface{}, error) {
-		seeds := val.([]*Host)
+	clstr.seeds.Update(func(seeds []*Host) ([]*Host, error) {
 		seeds = append(seeds, hosts...)
 		return seeds, nil
 	})
@@ -484,12 +484,7 @@ func (clstr *Cluster) waitTillStabilized() Error {
 }
 
 func (clstr *Cluster) findAlias(alias *Host) *Node {
-	res, _ := clstr.aliases.GetSyncedVia(func(val interface{}) (interface{}, error) {
-		aliases := val.(map[Host]*Node)
-		return aliases[*alias], nil
-	})
-
-	return res.(*Node)
+	return clstr.aliases.Get(*alias)
 }
 
 func (clstr *Cluster) setPartitions(partMap partitionMap) {
@@ -497,11 +492,11 @@ func (clstr *Cluster) setPartitions(partMap partitionMap) {
 		logger.Logger.Error("Partition map error: %s.", err.Error())
 	}
 
-	clstr.partitionWriteMap.Store(partMap)
+	clstr.partitionWriteMap.Set(partMap)
 }
 
 func (clstr *Cluster) getPartitions() partitionMap {
-	return clstr.partitionWriteMap.Load().(partitionMap)
+	return clstr.partitionWriteMap.Get()
 }
 
 // discoverSeeds will lookup the seed hosts and convert seed hosts
@@ -526,8 +521,7 @@ func discoverSeedIPs(seeds []*Host) (res []*Host) {
 // Adds seeds to the cluster
 func (clstr *Cluster) seedNodes() (newSeedsFound bool, errChain Error) {
 	// Must copy array reference for copy on write semantics to work.
-	seedArrayIfc, _ := clstr.seeds.GetSyncedVia(func(val interface{}) (interface{}, error) {
-		seeds := val.([]*Host)
+	seedArrayCopy, _ := clstr.seeds.GetSyncedVia(func(seeds []*Host) ([]*Host, error) {
 		seedsCopy := make([]*Host, len(seeds))
 		copy(seedsCopy, seeds)
 
@@ -535,7 +529,7 @@ func (clstr *Cluster) seedNodes() (newSeedsFound bool, errChain Error) {
 	})
 
 	// discover seed IPs from DNS or Load Balancers
-	seedArray := discoverSeedIPs(seedArrayIfc.([]*Host))
+	seedArray := discoverSeedIPs(seedArrayCopy)
 
 	successChan := make(chan struct{}, len(seedArray))
 	errChan := make(chan Error, len(seedArray))
@@ -603,11 +597,7 @@ func (clstr *Cluster) findNodeName(list []*Node, name string) bool {
 
 func (clstr *Cluster) addAlias(host *Host, node *Node) {
 	if host != nil && node != nil {
-		clstr.aliases.Update(func(val interface{}) (interface{}, error) {
-			aliases := val.(map[Host]*Node)
-			aliases[*host] = node
-			return aliases, nil
-		})
+		clstr.aliases.Set(*host, node)
 	}
 }
 
@@ -693,8 +683,7 @@ func (clstr *Cluster) addNodes(nodesToAdd map[string]*Node) {
 	// update features for all nodes
 	defer clstr.updateClusterFeatures()
 
-	clstr.nodes.Update(func(val interface{}) (interface{}, error) {
-		nodes := val.([]*Node)
+	clstr.nodes.Update(func(nodes []*Node) ([]*Node, error) {
 		if clstr.clientPolicy.SeedOnlyCluster && clstr.GetSeedCount() == len(nodes) {
 			// Don't add new nodes.
 			return nodes, nil
@@ -717,8 +706,8 @@ func (clstr *Cluster) addNodes(nodesToAdd map[string]*Node) {
 			}
 		}
 
-		clstr.nodesMap.Set(nodesMap)
-		clstr.aliases.Set(nodesAliases)
+		clstr.nodesMap.Replace(nodesMap)
+		clstr.aliases.Replace(nodesAliases)
 
 		return nodes, nil
 	})
@@ -739,26 +728,13 @@ func (clstr *Cluster) removeNodes(nodesToRemove []*Node) {
 	for _, node := range nodesToRemove {
 		// Remove node's aliases from cluster alias set.
 		// Aliases are only used in tend goroutine, so synchronization is not necessary.
-		clstr.aliases.Update(func(val interface{}) (interface{}, error) {
-			aliases := val.(map[Host]*Node)
-			for _, alias := range node.GetAliases() {
-				delete(aliases, *alias)
-			}
-			return aliases, nil
-		})
-
-		clstr.nodesMap.Update(func(val interface{}) (interface{}, error) {
-			nodesMap := val.(map[string]*Node)
-			delete(nodesMap, node.name)
-			return nodesMap, nil
-		})
-
+		clstr.aliases.DeleteAllDeref(node.GetAliases()...)
+		clstr.nodesMap.Delete(node.name)
 		node.Close()
 	}
 
 	// Remove all nodes at once to avoid copying entire array multiple times.
-	clstr.nodes.Update(func(val interface{}) (interface{}, error) {
-		nodes := val.([]*Node)
+	clstr.nodes.Update(func(nodes []*Node) ([]*Node, error) {
 		nlist := make([]*Node, 0, len(nodes))
 		nlist = append(nlist, nodes...)
 		for i, n := range nlist {
@@ -814,23 +790,21 @@ func (clstr *Cluster) GetRandomNode() (*Node, Error) {
 // GetNodes returns a list of all nodes in the cluster
 func (clstr *Cluster) GetNodes() []*Node {
 	// Must copy array reference for copy on write semantics to work.
-	return clstr.nodes.Get().([]*Node)
+	return clstr.nodes.Get()
 }
 
 // GetSeedCount is the count of seed nodes
 func (clstr *Cluster) GetSeedCount() int {
-	res, _ := clstr.seeds.GetSyncedVia(func(val interface{}) (interface{}, error) {
-		seeds := val.([]*Host)
+	res, _ := iatomic.MapSyncValue(&clstr.seeds, func(seeds []*Host) (int, error) {
 		return len(seeds), nil
 	})
 
-	return res.(int)
+	return res
 }
 
 // GetSeeds returns a list of all seed nodes in the cluster
 func (clstr *Cluster) GetSeeds() []Host {
-	res, _ := clstr.seeds.GetSyncedVia(func(val interface{}) (interface{}, error) {
-		seeds := val.([]*Host)
+	res, _ := iatomic.MapSyncValue(&clstr.seeds, func(seeds []*Host) ([]Host, error) {
 		res := make([]Host, 0, len(seeds))
 		for _, seed := range seeds {
 			res = append(res, *seed)
@@ -839,22 +813,12 @@ func (clstr *Cluster) GetSeeds() []Host {
 		return res, nil
 	})
 
-	return res.([]Host)
+	return res
 }
 
 // GetAliases returns a list of all node aliases in the cluster
 func (clstr *Cluster) GetAliases() map[Host]*Node {
-	res, _ := clstr.aliases.GetSyncedVia(func(val interface{}) (interface{}, error) {
-		aliases := val.(map[Host]*Node)
-		res := make(map[Host]*Node, len(aliases))
-		for h, n := range aliases {
-			res[h] = n
-		}
-
-		return res, nil
-	})
-
-	return res.(map[Host]*Node)
+	return clstr.aliases.Clone()
 }
 
 // GetNodeByName finds a node by name and returns an
@@ -962,7 +926,7 @@ func (clstr *Cluster) WaitUntillMigrationIsFinished(timeout time.Duration) Error
 func (clstr *Cluster) Password() (res []byte) {
 	pass := clstr.password.Get()
 	if pass != nil {
-		return pass.([]byte)
+		return pass
 	}
 	return nil
 }
@@ -1008,11 +972,7 @@ func (clstr *Cluster) WarmUp(count int) (int, Error) {
 
 // MetricsEnabled returns true if metrics are enabled for the cluster.
 func (clstr *Cluster) MetricsPolicy() *MetricsPolicy {
-	res := clstr.metricsPolicy.Load()
-	if res != nil {
-		return res.(*MetricsPolicy)
-	}
-	return nil
+	return clstr.metricsPolicy.Get()
 }
 
 // MetricsEnabled returns true if metrics are enabled for the cluster.
@@ -1028,7 +988,7 @@ func (clstr *Cluster) EnableMetrics(policy *MetricsPolicy) {
 		policy = DefaultMetricsPolicy()
 	}
 
-	clstr.metricsPolicy.Store(policy)
+	clstr.metricsPolicy.Set(policy)
 	clstr.metricsEnabled.Store(true)
 
 	clstr.statsLock.Lock()

--- a/connection.go
+++ b/connection.go
@@ -484,7 +484,7 @@ func (ctn *Connection) login(policy *ClientPolicy, hashedPassword []byte, sessio
 
 		si := command.sessionInfo()
 		if ctn.node != nil && si.isValid() {
-			ctn.node.sessionInfo.Store(si)
+			ctn.node.sessionInfo.Set(si)
 		}
 	}
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -14,8 +14,8 @@
 
 package aerospike
 
-func ParseIndexErrorCode(response string) Error {
-	return parseIndexErrorCode(response)
+func ParseInfoErrorCode(response string) Error {
+	return parseInfoErrorCode(response)
 }
 
 func (e *AerospikeError) Msg() string {

--- a/internal/atomic/guard.go
+++ b/internal/atomic/guard.go
@@ -1,0 +1,82 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomic
+
+import "sync"
+
+// Guard allows synchronized access to a value
+type Guard[T any] struct {
+	val *T
+	m   sync.Mutex
+}
+
+// NewGuard creates a new instance of Guard
+func NewGuard[T any](val *T) *Guard[T] {
+	return &Guard[T]{val: val}
+}
+
+// Do calls the passed closure.
+func (g *Guard[T]) Do(f func(*T)) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	f(g.val)
+}
+
+// DoVal calls the passed closure with a dereferenced internal value.
+func (g *Guard[T]) DoVal(f func(T)) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	f(*g.val)
+}
+
+// Call the passed closure allowing to replace the content.
+func (g *Guard[T]) Update(f func(**T)) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	f(&g.val)
+}
+
+// Calls the passed closure allowing to replace the content.
+// It will call the init func if the internal values is nil.
+func (g *Guard[T]) InitDo(init func() *T, f func(*T)) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	if g.val == nil {
+		g.val = init()
+	}
+	f(g.val)
+}
+
+// Calls the passed closure allowing to replace the content.
+// It will call the init func if the internal values is nil.
+// It is used for reference values like slices and maps.
+func (g *Guard[T]) InitDoVal(init func() T, f func(T)) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	if g.val == nil {
+		t := init()
+		g.val = &t
+	}
+	f(*g.val)
+}
+
+// Release returns the internal value and sets it to nil
+func (g *Guard[T]) Release() *T {
+	g.m.Lock()
+	defer g.m.Unlock()
+	res := g.val
+	g.val = nil
+	return res
+}

--- a/internal/atomic/guard_test.go
+++ b/internal/atomic/guard_test.go
@@ -1,0 +1,118 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomic_test
+
+import (
+	"runtime"
+
+	"github.com/aerospike/aerospike-client-go/v7/internal/atomic"
+
+	gg "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+)
+
+var _ = gg.Describe("Atomic Guard", func() {
+	// atomic tests require actual parallelism
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	type S struct {
+		a int
+		b bool
+	}
+
+	var grd *atomic.Guard[S]
+
+	gg.BeforeEach(func() {
+		grd = atomic.NewGuard[S](&S{a: 1, b: true})
+	})
+
+	gg.It("must pass internal value correctly", func() {
+		grd.Do(func(s *S) {
+			gm.Expect(*s).To(gm.Equal(S{a: 1, b: true}))
+		})
+
+	})
+
+	gg.It("must assign/copy internal value correctly", func() {
+		local := S{a: 99, b: false}
+		grd.Do(func(s *S) {
+			*s = local
+		})
+
+		grd.Do(func(s *S) {
+			gm.Expect(*s).To(gm.Equal(S{a: 99, b: false}))
+		})
+
+	})
+
+	gg.It("must initialize and assign internal value correctly", func() {
+		flocal := func() *S { return &S{a: 99, b: false} }
+
+		var grd atomic.Guard[S]
+		grd.Do(func(s *S) {
+			gm.Expect(s).To(gm.BeNil())
+		})
+
+		grd.InitDo(flocal, func(s *S) {
+			gm.Expect(*s).To(gm.Equal(S{a: 99, b: false}))
+			s.a++
+			s.b = true
+		})
+
+		grd.InitDo(flocal, func(s *S) {
+			gm.Expect(*s).To(gm.Equal(S{a: 100, b: true}))
+		})
+
+		grd.Do(func(s *S) {
+			gm.Expect(*s).To(gm.Equal(S{a: 100, b: true}))
+		})
+	})
+
+	gg.It("must initialize and assign internal value correctly", func() {
+		flocal := func() map[int]int { return map[int]int{1: 1, 2: 2, 3: 3} }
+
+		var grd atomic.Guard[map[int]int]
+		grd.Do(func(s *map[int]int) {
+			gm.Expect(s).To(gm.BeNil())
+		})
+
+		grd.InitDoVal(flocal, func(s map[int]int) {
+			gm.Expect(s).To(gm.Equal(map[int]int{1: 1, 2: 2, 3: 3}))
+		})
+
+		grd.InitDoVal(flocal, func(s map[int]int) {
+			gm.Expect(s).To(gm.Equal(map[int]int{1: 1, 2: 2, 3: 3}))
+			for i := 4; i < 100; i++ {
+				s[i] = i
+			}
+		})
+
+		grd.DoVal(func(s map[int]int) {
+			gm.Expect(len(s)).To(gm.Equal(99))
+		})
+	})
+
+	gg.It("must replace internal value's reference correctly", func() {
+		local := S{a: 99, b: false}
+		grd.Update(func(s **S) {
+			*s = &local
+		})
+
+		grd.Do(func(s *S) {
+			gm.Expect(s == &local).To(gm.BeTrue())
+		})
+
+	})
+})

--- a/internal/atomic/map/map.go
+++ b/internal/atomic/map/map.go
@@ -1,0 +1,118 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomic
+
+import (
+	"sync"
+)
+
+// Map implements a Map with atomic semantics.
+type Map[K comparable, V any] struct {
+	m     map[K]V
+	mutex sync.RWMutex
+}
+
+// New generates a new Map instance.
+func New[K comparable, V any](length int) *Map[K, V] {
+	return &Map[K, V]{
+		m: make(map[K]V, length),
+	}
+}
+
+// Get atomically retrieves an element from the Map.
+func (m *Map[K, V]) Get(k K) V {
+	m.mutex.RLock()
+	res := m.m[k]
+	m.mutex.RUnlock()
+	return res
+}
+
+// Set atomically sets an element in the Map.
+// If idx is out of range, it will return an error.
+func (m *Map[K, V]) Set(k K, v V) {
+	m.mutex.Lock()
+	m.m[k] = v
+	m.mutex.Unlock()
+}
+
+// Replace replaces the internal map with the provided one.
+func (m *Map[K, V]) Replace(nm map[K]V) {
+	m.mutex.Lock()
+	m.m = nm
+	m.mutex.Unlock()
+}
+
+// Length returns the Map size.
+func (m *Map[K, V]) Length() int {
+	m.mutex.RLock()
+	res := len(m.m)
+	m.mutex.RUnlock()
+
+	return res
+}
+
+// Length returns the Map size.
+func (m *Map[K, V]) Clone() map[K]V {
+	m.mutex.RLock()
+	res := make(map[K]V, len(m.m))
+	for k, v := range m.m {
+		res[k] = v
+	}
+	m.mutex.RUnlock()
+
+	return res
+}
+
+// Delete will remove the key and return its value.
+func (m *Map[K, V]) Delete(k K) V {
+	m.mutex.Lock()
+	res := m.m[k]
+	delete(m.m, k)
+	m.mutex.Unlock()
+	return res
+}
+
+// DeleteDeref will dereference and remove the key and return its value.
+func (m *Map[K, V]) DeleteDeref(k *K) V {
+	m.mutex.Lock()
+	res := m.m[*k]
+	delete(m.m, *k)
+	m.mutex.Unlock()
+	return res
+}
+
+// DeleteAllDeref will dereferences and removes the keys.
+func (m *Map[K, V]) DeleteAll(ks ...K) {
+	m.mutex.Lock()
+	for i := range ks {
+		delete(m.m, ks[i])
+	}
+	m.mutex.Unlock()
+}
+
+// DeleteAll will remove the keys.
+func (m *Map[K, V]) DeleteAllDeref(ks ...*K) {
+	m.mutex.Lock()
+	for i := range ks {
+		delete(m.m, *ks[i])
+	}
+	m.mutex.Unlock()
+}
+
+func MapAllF[K comparable, V any, U any](m *Map[K, V], f func(map[K]V) U) U {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return f(m.m)
+}

--- a/internal/atomic/sync_val.go
+++ b/internal/atomic/sync_val.go
@@ -3,25 +3,25 @@ package atomic
 import "sync"
 
 // SyncVal allows synchronized access to a value
-type SyncVal struct {
-	val  interface{}
+type SyncVal[T any] struct {
+	val  T
 	lock sync.RWMutex
 }
 
 // NewSyncVal creates a new instance of SyncVal
-func NewSyncVal(val interface{}) *SyncVal {
-	return &SyncVal{val: val}
+func NewSyncVal[T any](val T) *SyncVal[T] {
+	return &SyncVal[T]{val: val}
 }
 
 // Set updates the value of SyncVal with the passed argument
-func (sv *SyncVal) Set(val interface{}) {
+func (sv *SyncVal[T]) Set(val T) {
 	sv.lock.Lock()
 	sv.val = val
 	sv.lock.Unlock()
 }
 
 // Get returns the value inside the SyncVal
-func (sv *SyncVal) Get() interface{} {
+func (sv *SyncVal[T]) Get() T {
 	sv.lock.RLock()
 	val := sv.val
 	sv.lock.RUnlock()
@@ -29,7 +29,7 @@ func (sv *SyncVal) Get() interface{} {
 }
 
 // GetSyncedVia returns the value returned by the function f.
-func (sv *SyncVal) GetSyncedVia(f func(interface{}) (interface{}, error)) (interface{}, error) {
+func (sv *SyncVal[T]) GetSyncedVia(f func(T) (T, error)) (T, error) {
 	sv.lock.RLock()
 	defer sv.lock.RUnlock()
 
@@ -40,7 +40,7 @@ func (sv *SyncVal) GetSyncedVia(f func(interface{}) (interface{}, error)) (inter
 // Update gets a function and passes the value of SyncVal to it.
 // If the resulting err is nil, it will update the value of SyncVal.
 // It will return the resulting error to the caller.
-func (sv *SyncVal) Update(f func(interface{}) (interface{}, error)) error {
+func (sv *SyncVal[T]) Update(f func(T) (T, error)) error {
 	sv.lock.Lock()
 	defer sv.lock.Unlock()
 
@@ -49,4 +49,13 @@ func (sv *SyncVal) Update(f func(interface{}) (interface{}, error)) error {
 		sv.val = val
 	}
 	return err
+}
+
+// MapSyncValue returns the value returned by the function f.
+func MapSyncValue[T any, U any](sv *SyncVal[T], f func(T) (U, error)) (U, error) {
+	sv.lock.RLock()
+	defer sv.lock.RUnlock()
+
+	val, err := f(sv.val)
+	return val, err
 }

--- a/internal/atomic/typed_val.go
+++ b/internal/atomic/typed_val.go
@@ -1,0 +1,23 @@
+package atomic
+
+import "sync/atomic"
+
+// TypedVal allows synchronized access to a value
+type TypedVal[T any] atomic.Value
+
+// Set updates the value of TypedVal with the passed argument
+func (sv *TypedVal[T]) Set(val T) {
+	(*atomic.Value)(sv).Store(&val)
+}
+
+// Get returns the value inside the TypedVal
+func (sv *TypedVal[T]) Get() T {
+	res := (*atomic.Value)(sv).Load()
+	if res != nil {
+		return *res.(*T)
+	}
+
+	// return zero value; for pointers, it will be nil
+	var t T
+	return t
+}

--- a/internal/atomic/typed_val_test.go
+++ b/internal/atomic/typed_val_test.go
@@ -1,0 +1,126 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomic_test
+
+import (
+	"github.com/aerospike/aerospike-client-go/v7/internal/atomic"
+
+	gg "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+)
+
+var _ = gg.Describe("TypedVal", func() {
+
+	gg.Context("Storage must support", func() {
+
+		gg.Context("Primitives", func() {
+
+			gg.It("int", func() {
+				var t int = 5
+				var tv atomic.TypedVal[int]
+				tv.Set(t)
+				gm.Expect(tv.Get()).To(gm.Equal(t))
+			})
+
+			gg.It("string", func() {
+				var t string = "Hello!"
+				var tv atomic.TypedVal[string]
+				tv.Set(t)
+				gm.Expect(tv.Get()).To(gm.Equal(t))
+			})
+
+			gg.It("slice", func() {
+				var t = []int{1, 2, 3}
+				var tv atomic.TypedVal[[]int]
+				tv.Set(t)
+				gm.Expect(tv.Get()).To(gm.Equal(t))
+
+				tv.Set(nil)
+				var tt []int
+				gm.Expect(tv.Get()).To(gm.Equal(tt))
+			})
+
+			gg.It("map", func() {
+				var t = map[string]int{"a": 1, "b": 2, "c": 3}
+				var tv atomic.TypedVal[map[string]int]
+				tv.Set(t)
+				gm.Expect(tv.Get()).To(gm.Equal(t))
+
+				tv.Set(nil)
+				var tt map[string]int
+				gm.Expect(tv.Get()).To(gm.Equal(tt))
+			})
+
+		})
+
+		gg.Context("Pointers", func() {
+
+			gg.It("*int", func() {
+				var t int = 5
+				var tv atomic.TypedVal[*int]
+				tv.Set(&t)
+				gm.Expect(tv.Get()).To(gm.Equal(&t))
+
+				tv.Set(nil)
+				var tt *int
+				gm.Expect(tv.Get()).To(gm.Equal(tt))
+			})
+
+			gg.It("*string", func() {
+				var t string = "Hello!"
+				var tv atomic.TypedVal[*string]
+				tv.Set(&t)
+				gm.Expect(tv.Get()).To(gm.Equal(&t))
+
+				tv.Set(nil)
+				var tt *string
+				gm.Expect(tv.Get()).To(gm.Equal(tt))
+			})
+
+			gg.It("slice", func() {
+				var t = []int{1, 2, 3}
+				var tv atomic.TypedVal[*[]int]
+				tv.Set(&t)
+				gm.Expect(tv.Get()).To(gm.Equal(&t))
+
+				t = nil
+				tv.Set(&t)
+				gm.Expect(tv.Get()).To(gm.Equal(&t))
+
+				tv.Set(nil)
+				var tt *[]int
+				gm.Expect(tv.Get()).To(gm.Equal(tt))
+			})
+
+			gg.It("map", func() {
+				var t = map[string]int{"a": 1, "b": 2, "c": 3}
+				var tv atomic.TypedVal[*map[string]int]
+				tv.Set(&t)
+				gm.Expect(tv.Get()).To(gm.Equal(&t))
+
+				t = nil
+				tv.Set(&t)
+				gm.Expect(tv.Get()).To(gm.Equal(&t))
+
+				tv.Set(nil)
+				var tt *map[string]int
+				gm.Expect(tv.Get()).To(gm.Equal(tt))
+			})
+
+		})
+
+	})
+
+})

--- a/internal/seq/seq.go
+++ b/internal/seq/seq.go
@@ -1,0 +1,84 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seq
+
+import (
+	"errors"
+	"sync"
+)
+
+var Break = errors.New("Break")
+
+func Do[T any](seq []T, f func(T) error) {
+	for i := range seq {
+		if err := f(seq[i]); err == Break {
+			break
+		}
+	}
+}
+
+func ParDo[T any](seq []T, f func(T)) {
+	if len(seq) == 0 {
+		return
+	}
+
+	wg := new(sync.WaitGroup)
+	wg.Add(len(seq))
+	for i := range seq {
+		go func() {
+			defer wg.Done()
+			f(seq[i])
+		}()
+	}
+	wg.Wait()
+}
+
+func Any[T any](seq []T, f func(T) bool) bool {
+	for i := range seq {
+		if f(seq[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func All[T any](seq []T, f func(T) bool) bool {
+	if len(seq) == 0 {
+		return false
+	}
+
+	for i := range seq {
+		if !f(seq[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func Clone[T any](seq []T) []T {
+	if seq == nil {
+		return nil
+	}
+
+	if len(seq) == 0 {
+		return []T{}
+	}
+
+	res := make([]T, len(seq))
+	for i := range seq {
+		res[i] = seq[i]
+	}
+	return res
+}

--- a/proxy_client.go
+++ b/proxy_client.go
@@ -89,6 +89,11 @@ func grpcClientFinalizer(f *ProxyClient) {
 // If the policy is nil, the default relevant policy will be used.
 // Pass "dns:///<address>:<port>" (note the 3 slashes) for dns load balancing,
 // automatically supported internally by grpc-go.
+// The connection pool after connecting to the database is initially empty,
+// and connections are established on a per need basis, which can be slow and
+// time out some initial commands.
+// It is recommended to call the client.WarmUp() method right after connecting to the database
+// to fill up the connection pool to the required service level.
 func NewProxyClientWithPolicyAndHost(policy *ClientPolicy, host *Host, dialOptions ...grpc.DialOption) (*ProxyClient, Error) {
 	if policy == nil {
 		policy = NewClientPolicy()

--- a/proxy_client.go
+++ b/proxy_client.go
@@ -605,6 +605,11 @@ func (clnt *ProxyClient) GetHeader(policy *BasePolicy, key *Key) (*Record, Error
 // If the policy is nil, the default relevant policy will be used.
 func (clnt *ProxyClient) BatchGet(policy *BatchPolicy, keys []*Key, binNames ...string) ([]*Record, Error) {
 	policy = clnt.getUsableBatchPolicy(policy)
+
+	if len(keys) == 0 {
+		return []*Record{}, nil
+	}
+
 	batchRecordsIfc := make([]BatchRecordIfc, 0, len(keys))
 	batchRecords := make([]*BatchRecord, 0, len(keys))
 	for _, key := range keys {
@@ -633,6 +638,11 @@ func (clnt *ProxyClient) BatchGet(policy *BatchPolicy, keys []*Key, binNames ...
 // If a batch request to a node fails, the entire batch is cancelled.
 func (clnt *ProxyClient) BatchGetOperate(policy *BatchPolicy, keys []*Key, ops ...*Operation) ([]*Record, Error) {
 	policy = clnt.getUsableBatchPolicy(policy)
+
+	if len(keys) == 0 {
+		return []*Record{}, nil
+	}
+
 	batchRecordsIfc := make([]BatchRecordIfc, 0, len(keys))
 	batchRecords := make([]*BatchRecord, 0, len(keys))
 	for _, key := range keys {
@@ -682,6 +692,11 @@ func (clnt *ProxyClient) BatchGetComplex(policy *BatchPolicy, records []*BatchRe
 // If the policy is nil, the default relevant policy will be used.
 func (clnt *ProxyClient) BatchGetHeader(policy *BatchPolicy, keys []*Key) ([]*Record, Error) {
 	policy = clnt.getUsableBatchPolicy(policy)
+
+	if len(keys) == 0 {
+		return []*Record{}, nil
+	}
+
 	batchRecordsIfc := make([]BatchRecordIfc, 0, len(keys))
 	for _, key := range keys {
 		batchRecordsIfc = append(batchRecordsIfc, NewBatchReadHeader(clnt.DefaultBatchReadPolicy, key))
@@ -706,6 +721,11 @@ func (clnt *ProxyClient) BatchGetHeader(policy *BatchPolicy, keys []*Key) ([]*Re
 // Requires server version 6.0+
 func (clnt *ProxyClient) BatchDelete(policy *BatchPolicy, deletePolicy *BatchDeletePolicy, keys []*Key) ([]*BatchRecord, Error) {
 	policy = clnt.getUsableBatchPolicy(policy)
+
+	if len(keys) == 0 {
+		return []*BatchRecord{}, nil
+	}
+
 	deletePolicy = clnt.getUsableBatchDeletePolicy(deletePolicy)
 
 	batchRecordsIfc := make([]BatchRecordIfc, 0, len(keys))
@@ -755,6 +775,10 @@ func (clnt *ProxyClient) BatchOperate(policy *BatchPolicy, records []BatchRecord
 //
 // Requires server version 6.0+
 func (clnt *ProxyClient) BatchExecute(policy *BatchPolicy, udfPolicy *BatchUDFPolicy, keys []*Key, packageName string, functionName string, args ...Value) ([]*BatchRecord, Error) {
+	if len(keys) == 0 {
+		return []*BatchRecord{}, nil
+	}
+
 	batchRecordsIfc := make([]BatchRecordIfc, 0, len(keys))
 	batchRecords := make([]*BatchRecord, 0, len(keys))
 	for _, key := range keys {

--- a/proxy_client.go
+++ b/proxy_client.go
@@ -21,7 +21,6 @@ import (
 	"math/rand"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc"
@@ -44,7 +43,7 @@ type ProxyClient struct {
 	grpcHost     *Host
 	dialOptions  []grpc.DialOption
 
-	authToken       atomic.Value
+	authToken       iatomic.TypedVal[string]
 	authInterceptor *authInterceptor
 
 	active iatomic.Bool
@@ -260,11 +259,11 @@ func (clnt *ProxyClient) SetDefaultInfoPolicy(policy *InfoPolicy) {
 //-------------------------------------------------------
 
 func (clnt *ProxyClient) token() string {
-	return clnt.authToken.Load().(string)
+	return clnt.authToken.Get()
 }
 
 func (clnt *ProxyClient) setAuthToken(token string) {
-	clnt.authToken.Store(token)
+	clnt.authToken.Set(token)
 }
 
 func (clnt *ProxyClient) grpcConn() (*grpc.ClientConn, Error) {

--- a/types/result_code.go
+++ b/types/result_code.go
@@ -172,6 +172,9 @@ const (
 	// LOST_CONFLICT defines write command loses conflict to XDR.
 	LOST_CONFLICT = 28
 
+	// Write can't complete until XDR finishes shipping.
+	XDR_KEY_BUSY = 32
+
 	// QUERY_END defines there are no more records left for query.
 	QUERY_END ResultCode = 50
 
@@ -454,6 +457,9 @@ func ResultCodeToString(resultCode ResultCode) string {
 	case LOST_CONFLICT:
 		return "Write command loses conflict to XDR."
 
+	case XDR_KEY_BUSY:
+		return "Write can't complete until XDR finishes shipping."
+
 	case QUERY_END:
 		return "Query end"
 
@@ -691,6 +697,8 @@ func (rc ResultCode) String() string {
 		return "FILTERED_OUT"
 	case LOST_CONFLICT:
 		return "LOST_CONFLICT"
+	case XDR_KEY_BUSY:
+		return "XDR_KEY_BUSY"
 	case QUERY_END:
 		return "QUERY_END"
 	case SECURITY_NOT_SUPPORTED:

--- a/udf_test.go
+++ b/udf_test.go
@@ -65,6 +65,11 @@ function getRecordKeyValue(rec)
 end
 `
 
+const invalidUdfBody = `function testFunc1(rec, div)
+	asdf
+   returned ret                             -- Return the Return value and/or status
+end`
+
 // ALL tests are isolated by SetName and Key, which are 50 random characters
 var _ = gg.Describe("UDF/Query tests", func() {
 
@@ -94,6 +99,15 @@ var _ = gg.Describe("UDF/Query tests", func() {
 
 		// wait until UDF is created
 		gm.Expect(<-regTask.OnComplete()).NotTo(gm.HaveOccurred())
+	})
+
+	gg.It("must parse invalid UDF error", func() {
+		_, err := client.RegisterUDF(wpolicy, []byte(invalidUdfBody), "invalid_udf1.lua", as.LUA)
+		gm.Expect(err).To(gm.HaveOccurred())
+		gm.Expect(err.Error()).To(gm.HaveSuffix(`compile_error
+File: invalid_udf1.lua
+Line: 3
+Message: syntax error near 'returned'`))
 	})
 
 	gg.It("must run a UDF on a single record", func() {


### PR DESCRIPTION
  Minor improvement release.

- **Improvements**
  - [CLIENT-3112] Correctly handle new error messages/error codes returned by AS 7.2.
  - [CLIENT-3102] Add "XDR key busy" error code 32.
  - [CLIENT-3119] Use Generics For a General Code Clean Up.
    Uses several new generic containers to simplify concurrent access in the client.
    Uses a Guard as a monitor for the tend connection. This encapsulates synchronized tend connection management using said Guard.
  - Add documentation about client.WarmUp to the client initialization API.

- **Fixes**
  - [CLIENT-3082] `BatchGet` with empty Keys raises gRPC `EOF` error.

[CLIENT-3112]: https://aerospike.atlassian.net/browse/CLIENT-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3102]: https://aerospike.atlassian.net/browse/CLIENT-3102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3119]: https://aerospike.atlassian.net/browse/CLIENT-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3082]: https://aerospike.atlassian.net/browse/CLIENT-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ