### PR TITLE
Go Client v7.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change History
 
+## September 18 2024: v7.7.1
+
+  Hot Fix release. This version fixes a major bug introduced in v7.7.0. You should use this release instead.
+
+- **Fixes**
+  - [CLIENT-3122] Fix `nil` dereference in the tend logic.
+
 ## September 13 2024: v7.7.0
 
   Minor improvement release.
@@ -51,7 +58,7 @@
 - **Improvements**
   - [CLIENT-2997] Scans should work in a mixed cluster of v5.7 and v6.4 server nodes.
   - [CLIENT-3020] Change `ReadModeSC` doc from server to client perspective.
-  
+
 - **Fixes**
   - [CLIENT-3019] Prevent Goroutine leak in `AuthInterceptor` for the Proxy Client.
 

--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v7.3.0 // `Client.BatchGetOperate` issue
+retract (
+	v7.3.0 // `Client.BatchGetOperate` issue
+	v7.7.0 // nil deref in tend logic
+)

--- a/internal/seq/seq.go
+++ b/internal/seq/seq.go
@@ -37,10 +37,10 @@ func ParDo[T any](seq []T, f func(T)) {
 	wg := new(sync.WaitGroup)
 	wg.Add(len(seq))
 	for i := range seq {
-		go func() {
+		go func(t T) {
 			defer wg.Done()
-			f(seq[i])
-		}()
+			f(t)
+		}(seq[i])
 	}
 	wg.Wait()
 }
@@ -77,8 +77,6 @@ func Clone[T any](seq []T) []T {
 	}
 
 	res := make([]T, len(seq))
-	for i := range seq {
-		res[i] = seq[i]
-	}
+	copy(res, seq)
 	return res
 }


### PR DESCRIPTION
This version fixes a major bug introduced in v7.7.0. You should use this release instead.

- **Fixes**
  - [CLIENT-3122] Fix `nil` dereference in the tend logic.

[CLIENT-3122]: https://aerospike.atlassian.net/browse/CLIENT-3122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ