### PR TITLE
Fix concurrent map read/write in partition management

### DIFF
--- a/node.go
+++ b/node.go
@@ -353,7 +353,7 @@ func (nd *Node) refreshPeers(peers *peers) {
 	peers.refreshCount.IncrementAndGet()
 }
 
-func (nd *Node) refreshPartitions(peers *peers, partitions partitionMap, freshlyAdded bool) {
+func (nd *Node) refreshPartitions(peers *peers, partitions *partitionMap, freshlyAdded bool) {
 	// Do not refresh peers when node connection has already failed during this cluster tend iteration.
 	// Also, avoid "split cluster" case where this node thinks it's a 1-node cluster.
 	// Unchecked, such a node can dominate the partition map and cause all other

--- a/partition.go
+++ b/partition.go
@@ -58,10 +58,10 @@ func NewPartitionForReplicaPolicy(namespace string, replica ReplicaPolicy) *Part
 func PartitionForWrite(cluster *Cluster, policy *BasePolicy, key *Key) (*Partition, Error) {
 	// Must copy hashmap reference for copy on write semantics to work.
 	pmap := cluster.getPartitions()
-	partitions := pmap[key.namespace]
+	partitions, exists := pmap.get(key.namespace)
 
-	if partitions == nil {
-		return nil, newInvalidNamespaceError(key.namespace, len(pmap))
+	if !exists {
+		return nil, newInvalidNamespaceError(key.namespace, pmap.len())
 	}
 
 	return NewPartition(partitions, key, policy.ReplicaPolicy, nil, false), nil
@@ -71,10 +71,10 @@ func PartitionForWrite(cluster *Cluster, policy *BasePolicy, key *Key) (*Partiti
 func PartitionForRead(cluster *Cluster, policy *BasePolicy, key *Key) (*Partition, Error) {
 	// Must copy hashmap reference for copy on write semantics to work.
 	pmap := cluster.getPartitions()
-	partitions := pmap[key.namespace]
+	partitions, exists := pmap.get(key.namespace)
 
-	if partitions == nil {
-		return nil, newInvalidNamespaceError(key.namespace, len(pmap))
+	if !exists {
+		return nil, newInvalidNamespaceError(key.namespace, pmap.len())
 	}
 
 	var replica ReplicaPolicy
@@ -125,10 +125,10 @@ func GetReplicaPolicySC(policy *BasePolicy) ReplicaPolicy {
 func GetNodeBatchRead(cluster *Cluster, key *Key, replica ReplicaPolicy, replicaSC ReplicaPolicy, prevNode *Node, sequence int, sequenceSC int) (*Node, Error) {
 	// Must copy hashmap reference for copy on write semantics to work.
 	pmap := cluster.getPartitions()
-	partitions := pmap[key.namespace]
+	partitions, exists := pmap.get(key.namespace)
 
-	if partitions == nil {
-		return nil, newInvalidNamespaceError(key.namespace, len(pmap))
+	if !exists {
+		return nil, newInvalidNamespaceError(key.namespace, pmap.len())
 	}
 
 	if partitions.SCMode {
@@ -145,10 +145,10 @@ func GetNodeBatchRead(cluster *Cluster, key *Key, replica ReplicaPolicy, replica
 func GetNodeBatchWrite(cluster *Cluster, key *Key, replica ReplicaPolicy, prevNode *Node, sequence int) (*Node, Error) {
 	// Must copy hashmap reference for copy on write semantics to work.
 	pmap := cluster.getPartitions()
-	partitions := pmap[key.namespace]
+	partitions, exists := pmap.get(key.namespace)
 
-	if partitions == nil {
-		return nil, newInvalidNamespaceError(key.namespace, len(pmap))
+	if !exists {
+		return nil, newInvalidNamespaceError(key.namespace, pmap.len())
 	}
 
 	p := NewPartition(partitions, key, replica, prevNode, false)

--- a/partition_tracker.go
+++ b/partition_tracker.go
@@ -172,9 +172,9 @@ func (pt *partitionTracker) assignPartitionsToNodes(cluster *Cluster, namespace 
 	list := make([]*nodePartitions, 0, pt.nodeCapacity)
 
 	pMap := cluster.getPartitions()
-	parts := pMap[namespace]
+	parts, exists := pMap.get(namespace)
 
-	if parts == nil {
+	if !exists {
 		return nil, newError(types.INVALID_NAMESPACE, fmt.Sprintf("Invalid Partition Map for namespace `%s` in Partition Scan", namespace))
 	}
 


### PR DESCRIPTION
**Problem**
The current implementation of `partitionMap` is not thread-safe, leading to potential race conditions during concurrent read and write operations. This issue affects various parts of the codebase, including cluster management, node operations, and partition parsing.

**Issue References**
https://github.com/aerospike/aerospike-client-go/issues/446
https://github.com/aerospike/aerospike-client-go/issues/399

**Solution**
Implement a thread-safe `partitionMap` using `sync.Map` and update all related functions to use the new thread-safe methods. This change ensures safe concurrent access to partition data across multiple goroutines.

**Technical Notes**
`partitionMap` is a thread-safe map that stores partition information for different namespaces. It uses a `sync.Map` internally to provide concurrent read/write access without explicit locking. The keys are namespace names (strings), and the values are pointers to Partitions structs. This structure allows for efficient, concurrent operations on partition data across multiple goroutines.

```
Usage:
 - Use get(key) to retrieve partition data for a namespace
 - Use set(key, value) to update or add partition data for a namespace
 - Use iterate(func) to iterate over all namespace-partition pairs safely
 - Use delete(key) to remove partition data for a namespace
 - Use len() to get the number of namespaces in the map
```

**Changes**
partitions.go

* Redefined `partitionMap` to wrap a `sync.Map`
* Implemented thread-safe methods: get, set, delete, len, and iterate
* Updated clone and cleanup methods to work with the new structure

partition.go

* Modified `PartitionForWrite` and `PartitionForRead` to use new get method of `partitionMap`

partition_parser.go

* Updated partitionParser struct to use a pointer to `partitionMap`
* Modified parsing logic to use new thread-safe methods of `partitionMap`

node.go

* Updated `refreshPartitions` method to work with the new `partitionMap` structure

cluster.go

* Changed `partitionWriteMap` in Cluster struct to use a pointer to `partitionMap`
* Updated `setPartitions`, `getPartitions`, and `findNodeInPartitionMap` methods
* Modified `NewCluster` function to initialize `partitionWriteMap` correctly
* Updated `tend` method to use thread-safe operations on `partitionMap`

