### PR TITLE
3347 - Returning error if resultCode is not OK

### DIFF
--- a/txn_verify_batch_single.go
+++ b/txn_verify_batch_single.go
@@ -141,7 +141,6 @@ func (cmd *batchSingleTxnVerifyCommand) parseResult(ifc command, conn *Connectio
 			logger.Logger.Debug("Connection error reading data for ReadCommand: %s", err.Error())
 			return err
 		}
-
 	}
 
 	if resultCode == 0 {
@@ -149,6 +148,8 @@ func (cmd *batchSingleTxnVerifyCommand) parseResult(ifc command, conn *Connectio
 	} else {
 		err := newError(resultCode)
 		err.setInDoubt(cmd.isRead(), cmd.commandSentCounter)
+
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Fixing reported bug where single record transaction conflicts were ignored.


