### PR TITLE
Go Client v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change History
 
+## February 26 2025: v8.1.0
+
+- **New Features**
+  - [CLIENT-3334] Support old PHP7 client encoded boolean and null values.
+
+- **Fixes**
+  - [CLIENT-3347] MRT error occurrence varies depending on the number of records. PR #465, thanks to [Yevgeny Rizhkov](https://github.com/reugn)
+  - [CLIENT-3348] Parsing error during node rack update.
+  - Fix `nil` check for error in `executeIter` method. PR #465, thanks to [Oleksii](https://github.com/lesha888)
+
+- **Improvements**
+  - [CLIENT-3349] Reject BinNames > 15 bytes on client-side.
+
 ## February 5 2025: v8.0.1
 
 - **Fixes**

--- a/client_test.go
+++ b/client_test.go
@@ -197,7 +197,7 @@ var _ = gg.Describe("Aerospike", func() {
 				c, err := as.NewClientWithPolicyAndHost(&cpolicy, dbHost)
 				gm.Expect(err).NotTo(gm.HaveOccurred())
 
-				info := info(c, "racks:")
+				info := info(c, "rack-ids")
 				if strings.HasPrefix(strings.ToUpper(info), "ERROR") {
 					gg.Skip("Skipping RackAware test since it is not supported on this cluster...")
 				}

--- a/client_test.go
+++ b/client_test.go
@@ -259,6 +259,191 @@ var _ = gg.Describe("Aerospike", func() {
 		})
 	})
 
+	gg.Describe("Client-side limitations", func() {
+		gg.Context("Bin size limit of 15 bytes should be respected on", func() {
+			const longBinName = "binNameLongerThan15Bytes"
+			var ns = *namespace
+			var set = randString(50)
+			key, err = as.NewKey(ns, set, randString(50))
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			gg.It("Get", func() {
+				_, err := client.Get(nil, key, longBinName)
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("Put", func() {
+				err := client.Put(nil, key, as.BinMap{longBinName: 1})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("PutBins", func() {
+				err := client.PutBins(nil, key, as.NewBin(longBinName, 1))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("Add", func() {
+				err := client.Add(nil, key, as.BinMap{longBinName: 1})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("AddBins", func() {
+				err := client.AddBins(nil, key, as.NewBin(longBinName, 1))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("Append", func() {
+				err := client.Append(nil, key, as.BinMap{longBinName: 1})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("Prepend", func() {
+				err := client.Append(nil, key, as.BinMap{longBinName: 1})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("Operate", func() {
+				_, err := client.Operate(nil, key, as.GetBinOp(longBinName))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				_, err = client.Operate(nil, key, as.PutOp(as.NewBin(longBinName, 1)))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				_, err = client.Operate(nil, key, as.AddOp(as.NewBin(longBinName, 1)))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				_, err = client.Operate(nil, key, as.AppendOp(as.NewBin(longBinName, "1")))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				_, err = client.Operate(nil, key, as.PrependOp(as.NewBin(longBinName, "1")))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("BatchGetOperate", func() {
+				_, err := client.BatchGetOperate(nil, []*as.Key{key}, as.GetBinOp(longBinName))
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("BatchReadComplex", func() {
+				err := client.BatchGetComplex(nil, []*as.BatchRead{as.NewBatchRead(nil, key, []string{longBinName})})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				err = client.BatchGetComplex(nil, []*as.BatchRead{as.NewBatchReadOps(nil, key, as.GetBinOp(longBinName))})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("BatchOperate", func() {
+				err := client.BatchOperate(nil, []as.BatchRecordIfc{as.NewBatchRead(nil, key, []string{longBinName})})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				err = client.BatchOperate(nil, []as.BatchRecordIfc{as.NewBatchReadOps(nil, key, as.GetBinOp(longBinName))})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				err = client.BatchOperate(nil, []as.BatchRecordIfc{as.NewBatchWrite(nil, key, as.PutOp(as.NewBin(longBinName, 1)))})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				err = client.BatchOperate(nil, []as.BatchRecordIfc{as.NewBatchWrite(nil, key, as.AddOp(as.NewBin(longBinName, 1)))})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				err = client.BatchOperate(nil, []as.BatchRecordIfc{as.NewBatchWrite(nil, key, as.AppendOp(as.NewBin(longBinName, "1")))})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+
+				err = client.BatchOperate(nil, []as.BatchRecordIfc{as.NewBatchWrite(nil, key, as.PrependOp(as.NewBin(longBinName, "1")))})
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+			})
+
+			gg.It("Scan", func() {
+				rs, _ := client.ScanAll(nil, ns, set, longBinName)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+
+			gg.It("ScanPartitions", func() {
+				rs, _ := client.ScanPartitions(nil, nil, ns, set, longBinName)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+
+			gg.It("ScanNode", func() {
+				rs, _ := client.ScanNode(nil, nil, ns, set, longBinName)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+
+			gg.It("ScanNode", func() {
+				rs, _ := client.ScanNode(nil, nil, ns, set, longBinName)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+
+			gg.It("Query", func() {
+				stm := as.NewStatement(ns, set)
+				stm.BinNames = []string{longBinName}
+				rs, _ := client.Query(nil, stm)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+
+			gg.It("QueryPartitions", func() {
+				stm := as.NewStatement(ns, set)
+				stm.BinNames = []string{longBinName}
+				rs, _ := client.QueryPartitions(nil, stm, nil)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+
+			gg.It("QueryNode", func() {
+				stm := as.NewStatement(ns, set)
+				stm.BinNames = []string{longBinName}
+				rs, _ := client.QueryNode(nil, nil, stm)
+				for res := range rs.Results() {
+					err := res.Err
+					gm.Expect(err).To(gm.HaveOccurred())
+					gm.Expect(err.Matches(types.BIN_NAME_TOO_LONG)).To(gm.BeTrue())
+				}
+			})
+		})
+	})
+
 	gg.Describe("Data operations on native types", func() {
 		// connection data
 		var err error

--- a/command.go
+++ b/command.go
@@ -926,7 +926,9 @@ func (cmd *baseCommand) setRead(policy *BasePolicy, key *Key, binNames []string)
 		}
 
 		for i := range binNames {
-			cmd.writeOperationForBinName(binNames[i], _READ)
+			if err := cmd.writeOperationForBinName(binNames[i], _READ); err != nil {
+				return err
+			}
 		}
 		cmd.end()
 		cmd.markCompressed(policy)
@@ -1216,10 +1218,14 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 
 				attr.setBatchRead(client.getUsableBatchReadPolicy(br.Policy))
 				if len(br.BinNames) > 0 {
-					cmd.writeBatchBinNames(key, txn, ver, br.BinNames, attr, attr.filterExp)
+					if err := cmd.writeBatchBinNames(key, txn, ver, br.BinNames, attr, attr.filterExp); err != nil {
+						return nil, err
+					}
 				} else if br.Ops != nil {
 					attr.adjustRead(br.Ops)
-					cmd.writeBatchOperations(key, txn, ver, br.Ops, attr, attr.filterExp)
+					if err := cmd.writeBatchOperations(key, txn, ver, br.Ops, attr, attr.filterExp); err != nil {
+						return nil, err
+					}
 				} else {
 					attr.adjustReadForAllBins(br.ReadAllBins)
 					cmd.writeBatchRead(key, txn, ver, attr, attr.filterExp, 0)
@@ -1230,7 +1236,9 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 
 				attr.setBatchWrite(client.getUsableBatchWritePolicy(bw.Policy))
 				attr.adjustWrite(bw.Ops)
-				cmd.writeBatchOperations(key, txn, ver, bw.Ops, attr, attr.filterExp)
+				if err := cmd.writeBatchOperations(key, txn, ver, bw.Ops, attr, attr.filterExp); err != nil {
+					return nil, err
+				}
 
 			case _BRT_BATCH_UDF:
 				bu := record.(*BatchUDF)
@@ -1393,10 +1401,14 @@ func (cmd *baseCommand) setBatchOperateReadOffsets(
 			// Write full message.
 			attr.setBatchRead(client.getUsableBatchReadPolicy(record.Policy))
 			if len(record.BinNames) > 0 {
-				cmd.writeBatchBinNames(key, txn, ver, record.BinNames, attr, attr.filterExp)
+				if err := cmd.writeBatchBinNames(key, txn, ver, record.BinNames, attr, attr.filterExp); err != nil {
+					return nil, err
+				}
 			} else if record.Ops != nil {
 				attr.adjustRead(record.Ops)
-				cmd.writeBatchOperations(key, txn, ver, record.Ops, attr, attr.filterExp)
+				if err := cmd.writeBatchOperations(key, txn, ver, record.Ops, attr, attr.filterExp); err != nil {
+					return nil, err
+				}
 			} else {
 				attr.adjustReadForAllBins(record.ReadAllBins)
 				cmd.writeBatchRead(key, txn, ver, attr, attr.filterExp, 0)
@@ -1572,9 +1584,13 @@ func (cmd *baseCommand) setBatchOperateOffsets(
 		} else {
 			// Write full header, namespace and bin names.
 			if len(binNames) > 0 {
-				cmd.writeBatchBinNames(key, txn, ver, binNames, attr, nil)
+				if err := cmd.writeBatchBinNames(key, txn, ver, binNames, attr, nil); err != nil {
+					return err
+				}
 			} else if len(ops) > 0 {
-				cmd.writeBatchOperations(key, txn, ver, ops, attr, nil)
+				if err := cmd.writeBatchOperations(key, txn, ver, ops, attr, nil); err != nil {
+					return err
+				}
 			} else if (attr.writeAttr & _INFO2_DELETE) != 0 {
 				cmd.writeBatchWrite(key, txn, ver, attr, nil, 0, 0)
 			} else {
@@ -1790,12 +1806,15 @@ func (cmd *baseCommand) writeBatchBinNames(
 	binNames []string,
 	attr *batchAttr,
 	filter *Expression,
-) {
+) Error {
 	cmd.writeBatchRead(key, txn, ver, attr, filter, len(binNames))
 
 	for i := range binNames {
-		cmd.writeOperationForBinName(binNames[i], _READ)
+		if err := cmd.writeOperationForBinName(binNames[i], _READ); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (cmd *baseCommand) writeBatchOperations(
@@ -1805,7 +1824,7 @@ func (cmd *baseCommand) writeBatchOperations(
 	ops []*Operation,
 	attr *batchAttr,
 	filter *Expression,
-) {
+) Error {
 	if attr.hasWrite {
 		cmd.writeBatchWrite(key, txn, ver, attr, filter, 0, len(ops))
 	} else {
@@ -1813,8 +1832,11 @@ func (cmd *baseCommand) writeBatchOperations(
 	}
 
 	for i := range ops {
-		cmd.writeOperationForOperation(ops[i])
+		if err := cmd.writeOperationForOperation(ops[i]); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (cmd *baseCommand) writeBatchRead(
@@ -1990,7 +2012,9 @@ func (cmd *baseCommand) setBatchRead(policy *BatchPolicy, keys []*Key, batch *ba
 				cmd.WriteByte(byte(readAttr))
 				cmd.writeBatchFields(key, 0, len(binNames))
 				for _, binName := range binNames {
-					cmd.writeOperationForBinName(binName, _READ)
+					if err := cmd.writeOperationForBinName(binName, _READ); err != nil {
+						return err
+					}
 				}
 			} else if len(ops) > 0 {
 				offset := cmd.dataOffset
@@ -2131,7 +2155,9 @@ func (cmd *baseCommand) setBatchIndexRead(policy *BatchPolicy, records []*BatchR
 				cmd.WriteByte(byte(readAttr))
 				cmd.writeBatchFields(key, 0, len(binNames))
 				for _, binName := range binNames {
-					cmd.writeOperationForBinName(binName, _READ)
+					if err := cmd.writeOperationForBinName(binName, _READ); err != nil {
+						return err
+					}
 				}
 			} else if len(ops) > 0 {
 				offset := cmd.dataOffset
@@ -2406,7 +2432,9 @@ func (cmd *baseCommand) setScan(policy *ScanPolicy, namespace *string, setName *
 	cmd.WriteUint64(taskID)
 
 	for i := range binNames {
-		cmd.writeOperationForBinName(binNames[i], _READ)
+		if err := cmd.writeOperationForBinName(binNames[i], _READ); err != nil {
+			return err
+		}
 	}
 
 	cmd.end()
@@ -2758,7 +2786,9 @@ func (cmd *baseCommand) setQuery(policy *QueryPolicy, wpolicy *WritePolicy, stat
 	} else if len(statement.BinNames) > 0 && (isNew || statement.Filter == nil) {
 		// scan binNames come last
 		for _, binName := range statement.BinNames {
-			cmd.writeOperationForBinName(binName, _READ)
+			if err := cmd.writeOperationForBinName(binName, _READ); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -3180,6 +3210,9 @@ func (cmd *baseCommand) writeKey(key *Key) Error {
 
 func (cmd *baseCommand) writeOperationForBin(bin *Bin, operation OperationType) Error {
 	nameLength := copy(cmd.dataBuffer[(cmd.dataOffset+int(_OPERATION_HEADER_SIZE)):], bin.Name)
+	if nameLength > 15 {
+		return newError(types.BIN_NAME_TOO_LONG, fmt.Sprintf("Bin name `%s` too long, it cannot be longer than 15 bytes.", bin.Name))
+	}
 
 	valueLength, err := bin.Value.EstimateSize()
 	if err != nil {
@@ -3198,6 +3231,9 @@ func (cmd *baseCommand) writeOperationForBin(bin *Bin, operation OperationType) 
 
 func (cmd *baseCommand) writeOperationForBinNameAndValue(name string, val interface{}, operation OperationType) Error {
 	nameLength := copy(cmd.dataBuffer[(cmd.dataOffset+int(_OPERATION_HEADER_SIZE)):], name)
+	if nameLength > 15 {
+		return newError(types.BIN_NAME_TOO_LONG, fmt.Sprintf("Bin name `%s` too long, it cannot be longer than 15 bytes.", name))
+	}
 
 	v := NewValue(val)
 
@@ -3238,6 +3274,9 @@ func (cmd *baseCommand) writeBatchReadOperations(ops []*Operation, readAttr int)
 
 func (cmd *baseCommand) writeOperationForOperation(operation *Operation) Error {
 	nameLength := copy(cmd.dataBuffer[(cmd.dataOffset+int(_OPERATION_HEADER_SIZE)):], operation.binName)
+	if nameLength > 15 {
+		return newError(types.BIN_NAME_TOO_LONG, fmt.Sprintf("Bin name `%s` too long, it cannot be longer than 15 bytes.", operation.binName))
+	}
 
 	if operation.encoder == nil {
 		valueLength, err := operation.binValue.EstimateSize()
@@ -3270,14 +3309,18 @@ func (cmd *baseCommand) writeOperationForOperation(operation *Operation) Error {
 	return err
 }
 
-func (cmd *baseCommand) writeOperationForBinName(name string, operation OperationType) {
+func (cmd *baseCommand) writeOperationForBinName(name string, operation OperationType) Error {
 	nameLength := copy(cmd.dataBuffer[(cmd.dataOffset+int(_OPERATION_HEADER_SIZE)):], name)
+	if nameLength > 15 {
+		return newError(types.BIN_NAME_TOO_LONG, fmt.Sprintf("Bin name `%s` too long, it cannot be longer than 15 bytes.", name))
+	}
 	cmd.WriteInt32(int32(nameLength + 4))
 	cmd.WriteByte((operation.op))
 	cmd.WriteByte(byte(0))
 	cmd.WriteByte(byte(0))
 	cmd.WriteByte(byte(nameLength))
 	cmd.dataOffset += nameLength
+	return nil
 }
 
 func (cmd *baseCommand) writeOperationForOperationType(operation OperationType) {

--- a/command.go
+++ b/command.go
@@ -3553,7 +3553,7 @@ func (cmd *baseCommand) executeIter(ifc command, iter int) Error {
 	deadline := policy.deadline()
 
 	err := cmd.executeAt(ifc, policy, deadline, iter)
-	if err.IsInDoubt() {
+	if err != nil && err.IsInDoubt() {
 		cmd.onInDoubt()
 	}
 	return err

--- a/node.go
+++ b/node.go
@@ -15,9 +15,7 @@
 package aerospike
 
 import (
-	"bufio"
 	"errors"
-	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -143,7 +141,7 @@ func (nd *Node) Refresh(peers *peers) Error {
 	var infoMap map[string]string
 	commands := []string{"node", "peers-generation", "partition-generation"}
 	if nd.cluster.clientPolicy.RackAware {
-		commands = append(commands, "racks:")
+		commands = append(commands, "rack-ids")
 	}
 
 	infoMap, err := nd.RequestInfo(&nd.cluster.infoPolicy, commands...)
@@ -174,7 +172,7 @@ func (nd *Node) Refresh(peers *peers) Error {
 			return err
 		}
 		// Should not fail in other cases
-		logger.Logger.Warn("Updating node rack info failed with error: %s (racks: `%s`)", err, infoMap["racks:"])
+		logger.Logger.Warn("Updating node rack info failed with error: %s (rack-ids: `%s`)", err, infoMap["rack-ids"])
 	}
 
 	nd.failures.Set(0)
@@ -228,57 +226,31 @@ func (nd *Node) updateRackInfo(infoMap map[string]string) Error {
 		return nil
 	}
 
-	// Do not raise an error if the server does not support rackaware
-	if strings.HasPrefix(strings.ToUpper(infoMap["racks:"]), "ERROR") {
+	// Receive format: <ns1>:<rack1>;<ns2>:<rack2>...
+	rackIds := infoMap["rack-ids"]
+
+	// Do not panic if the server does not support rackaware
+	if len(rackIds) == 0 || strings.HasPrefix(strings.ToUpper(rackIds), "ERROR") {
 		return newError(types.UNSUPPORTED_FEATURE, "You have set the ClientPolicy.RackAware = true, but the server does not support this feature.")
 	}
 
-	ss := strings.Split(infoMap["racks:"], ";")
-	racks := map[string]int{}
-	for _, s := range ss {
-		in := bufio.NewReader(strings.NewReader(s))
-		_, err := in.ReadString('=')
+	rackPairs := strings.Split(rackIds, ";")
+	racks := make(map[string]int)
+	for i := range rackPairs {
+		// split at the last occurrence of `:` to ensure rack will be an integer
+		lastIdx := strings.LastIndex(rackPairs[i], ":")
+		if lastIdx < 0 {
+			return newError(types.PARSE_ERROR, "invalid rack value `%s`", rackPairs[i])
+		}
+
+		ns := rackPairs[i][:lastIdx]
+		rack := rackPairs[i][lastIdx+1:]
+
+		rackNo, err := strconv.Atoi(rack)
 		if err != nil {
 			return newErrorAndWrap(err, types.PARSE_ERROR)
 		}
-
-		ns, err := in.ReadString(':')
-		if err != nil {
-			return newErrorAndWrap(err, types.PARSE_ERROR)
-		}
-
-		for {
-			_, err = in.ReadString('_')
-			if err != nil {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			rackStr, err := in.ReadString('=')
-			if err != nil {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			rack, err := strconv.Atoi(rackStr[:len(rackStr)-1])
-			if err != nil {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			nodesList, err := in.ReadString(':')
-			if err != nil && err != io.EOF {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			nodes := strings.Split(strings.Trim(nodesList, ":"), ",")
-			for i := range nodes {
-				if nodes[i] == nd.name {
-					racks[ns[:len(ns)-1]] = rack
-				}
-			}
-
-			if err == io.EOF {
-				break
-			}
-		}
+		racks[ns] = rackNo
 	}
 
 	nd.racks.Set(racks)

--- a/txn_roll_batch_single.go
+++ b/txn_roll_batch_single.go
@@ -92,8 +92,7 @@ func (cmd *batchSingleTxnRollCommand) parseResult(ifc command, conn *Connection)
 		cmd.record.ResultCode = types.OK
 	} else {
 		err := newError(rp.resultCode)
-		err.setInDoubt(cmd.isRead(), cmd.commandSentCounter)
-		return err
+		return err.setInDoubt(cmd.isRead(), cmd.commandSentCounter)
 	}
 
 	return nil

--- a/txn_test.go
+++ b/txn_test.go
@@ -742,5 +742,36 @@ var _ = gg.Describe("Aerospike", func() {
 
 			gm.Expect(getGen(client, key, nil)).To(gm.Equal(7))
 		}) // it
+
+		gg.It("must ensure MRT_VERSION_MISMATCH is always returned regardless of the number of records", func() {
+			for _, count := range []int{1, 10, 100, 1000} {
+				var keys []*as.Key
+				for i := 0; i < count; i++ {
+					key, _ := as.NewKey(ns, set, i)
+					err := client.PutBins(nil, key, as.NewBin("bin", 1000))
+					gm.Expect(err).NotTo(gm.HaveOccurred())
+					keys = append(keys, key)
+				}
+
+				txn := as.NewTxn()
+
+				for _, key := range keys {
+					p := as.NewPolicy()
+					p.Txn = txn
+					rec, err := client.Get(p, key)
+					gm.Expect(err).NotTo(gm.HaveOccurred())
+					gm.Expect(rec).NotTo(gm.BeNil())
+				}
+
+				key0, _ := as.NewKey(ns, set, 0)
+				err := client.PutBins(nil, key0, as.NewBin("bin", 999))
+				gm.Expect(err).NotTo(gm.HaveOccurred())
+
+				_, err = client.Commit(txn)
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.MRT_VERSION_MISMATCH)).To(gm.BeTrue())
+			}
+		})
+
 	}) // describe
 })

--- a/txn_verify_batch_single.go
+++ b/txn_verify_batch_single.go
@@ -141,14 +141,13 @@ func (cmd *batchSingleTxnVerifyCommand) parseResult(ifc command, conn *Connectio
 			logger.Logger.Debug("Connection error reading data for ReadCommand: %s", err.Error())
 			return err
 		}
-
 	}
 
 	if resultCode == 0 {
 		cmd.record.ResultCode = types.OK
 	} else {
 		err := newError(resultCode)
-		err.setInDoubt(cmd.isRead(), cmd.commandSentCounter)
+		return err.setInDoubt(cmd.isRead(), cmd.commandSentCounter)
 	}
 
 	return nil

--- a/types/particle_type/particle_type.go
+++ b/types/particle_type/particle_type.go
@@ -17,17 +17,18 @@ package particleType
 // Server particle types. Unsupported types are commented out.
 const (
 	//revive:disable
-	NULL    = 0
-	INTEGER = 1
-	FLOAT   = 2
-	STRING  = 3
-	BLOB    = 4
-	DIGEST  = 6
-	BOOL    = 17
-	HLL     = 18
-	MAP     = 19
-	LIST    = 20
-	LDT     = 21
-	GEOJSON = 23
+	NULL     = 0
+	INTEGER  = 1
+	FLOAT    = 2
+	STRING   = 3
+	BLOB     = 4
+	DIGEST   = 6
+	PHP_BLOB = 11 // Had to reintroduce to support the old PHP7 client
+	BOOL     = 17
+	HLL      = 18
+	MAP      = 19
+	LIST     = 20
+	LDT      = 21
+	GEOJSON  = 23
 	//revive:enable
 )

--- a/value.go
+++ b/value.go
@@ -15,6 +15,7 @@
 package aerospike
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -1246,6 +1247,22 @@ func bytesToParticle(ptype int, buf []byte, offset int, length int) (interface{}
 	case ParticleType.LDT:
 		return newUnpacker(buf, offset, length).unpackObjects()
 
+	case ParticleType.PHP_BLOB:
+		if length == 4 {
+			if bytes.Equal(buf[offset:offset+length], []byte{0x62, 0x3A, 0x31, 0x3B}) {
+				return true, nil
+			} else if bytes.Equal(buf[offset:offset+length], []byte{0x62, 0x3A, 0x30, 0x3B}) {
+				return false, nil
+			}
+		} else if length == 2 {
+			if bytes.Equal(buf[offset:offset+length], []byte{0x4E, 0x3B}) {
+				return nil, nil
+			}
+		}
+		// generic PHP_BLOB
+		newObj := make([]byte, length)
+		copy(newObj, buf[offset:offset+length])
+		return newObj, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
- **New Features**
  - [CLIENT-3334] Support old PHP7 client encoded `boolean` and `null` values.

- **Fixes**
  - [CLIENT-3347] MRT error occurrence varies depending on the number of records. PR #465, thanks to [Yevgeny Rizhkov](https://github.com/reugn)
  - [CLIENT-3348] Parsing error during node rack update.
  - Fix `nil` check for error in `executeIter` method. PR #465, thanks to [Oleksii](https://github.com/lesha888)

- **Improvements**
  - [CLIENT-3349] Reject BinNames > 15 bytes on client-side.

[CLIENT-3334]: https://aerospike.atlassian.net/browse/CLIENT-3334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3347]: https://aerospike.atlassian.net/browse/CLIENT-3347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3348]: https://aerospike.atlassian.net/browse/CLIENT-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3349]: https://aerospike.atlassian.net/browse/CLIENT-3349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ