### PR TITLE
MarshalToBinMap function expose

### DIFF
--- a/client_reflect.go
+++ b/client_reflect.go
@@ -52,7 +52,7 @@ func (clnt *Client) PutObject(policy *WritePolicy, key *Key, obj interface{}) (e
 		}
 	}
 
-	binMap := marshal(obj)
+	binMap := MarshalToBinMap(obj)
 	command, err := newWriteCommand(clnt.cluster, policy, key, nil, binMap, _WRITE)
 	if err != nil {
 		return err

--- a/marshal.go
+++ b/marshal.go
@@ -216,7 +216,7 @@ func structToMap(s reflect.Value) BinMap {
 	return binMap
 }
 
-func marshal(v interface{}) BinMap {
+func MarshalToBinMap(v interface{}) BinMap {
 	s := indirect(reflect.ValueOf(v))
 	return structToMap(s)
 }


### PR DESCRIPTION
MarshalToBinMap Which helps to create BinMap for object with aerospike tag why? when there is need for bulk write this can be handy to marshal object to binmap later to bulkwrite ops