### PR TITLE
Go Client v6.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change History
 
+## March 13 2025: v6.16.1
+
+  Minor fix release.
+
+- **Fixes**
+  - [CLIENT-3156] Fix an issue where rack policy always returns the master node. Resolves #455
+
 ## April 10 2024: v6.15.1
 
 This release updates the dependencies to mitigate security issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change History
 
-## March 13 2025: v6.16.1
+## March 13 2025: v6.16.0
 
-  Minor fix release.
+  Minor backported fix release.
 
 - **Fixes**
   - [CLIENT-3156] Fix an issue where rack policy always returns the master node. Resolves #455
+  - [CLIENT-3348] Parsing error during node rack update.
 
 ## April 10 2024: v6.15.1
 

--- a/client_test.go
+++ b/client_test.go
@@ -166,7 +166,7 @@ var _ = gg.Describe("Aerospike", func() {
 				c, err := as.NewClientWithPolicyAndHost(&cpolicy, dbHost)
 				gm.Expect(err).NotTo(gm.HaveOccurred())
 
-				info := info(c, "racks:")
+				info := info(c, "rack-ids")
 				if strings.HasPrefix(strings.ToUpper(info), "ERROR") {
 					gg.Skip("Skipping RackAware test since it is not supported on this cluster...")
 				}

--- a/node.go
+++ b/node.go
@@ -15,9 +15,7 @@
 package aerospike
 
 import (
-	"bufio"
 	"errors"
-	"io"
 	"strconv"
 	"strings"
 	"sync"
@@ -142,7 +140,7 @@ func (nd *Node) Refresh(peers *peers) Error {
 	var infoMap map[string]string
 	commands := []string{"node", "peers-generation", "partition-generation"}
 	if nd.cluster.clientPolicy.RackAware {
-		commands = append(commands, "racks:")
+		commands = append(commands, "rack-ids")
 	}
 
 	infoMap, err := nd.RequestInfo(&nd.cluster.infoPolicy, commands...)
@@ -173,7 +171,7 @@ func (nd *Node) Refresh(peers *peers) Error {
 			return err
 		}
 		// Should not fail in other cases
-		logger.Logger.Warn("Updating node rack info failed with error: %s (racks: `%s`)", err, infoMap["racks:"])
+		logger.Logger.Warn("Updating node rack info failed with error: %s (rack-ids: `%s`)", err, infoMap["rack-ids"])
 	}
 
 	nd.failures.Set(0)
@@ -232,57 +230,31 @@ func (nd *Node) updateRackInfo(infoMap map[string]string) Error {
 		return nil
 	}
 
-	// Do not raise an error if the server does not support rackaware
-	if strings.HasPrefix(strings.ToUpper(infoMap["racks:"]), "ERROR") {
+	// Receive format: <ns1>:<rack1>;<ns2>:<rack2>...
+	rackIds := infoMap["rack-ids"]
+
+	// Do not panic if the server does not support rackaware
+	if len(rackIds) == 0 || strings.HasPrefix(strings.ToUpper(rackIds), "ERROR") {
 		return newError(types.UNSUPPORTED_FEATURE, "You have set the ClientPolicy.RackAware = true, but the server does not support this feature.")
 	}
 
-	ss := strings.Split(infoMap["racks:"], ";")
-	racks := map[string]int{}
-	for _, s := range ss {
-		in := bufio.NewReader(strings.NewReader(s))
-		_, err := in.ReadString('=')
+	rackPairs := strings.Split(rackIds, ";")
+	racks := make(map[string]int)
+	for i := range rackPairs {
+		// split at the last occurrence of `:` to ensure rack will be an integer
+		lastIdx := strings.LastIndex(rackPairs[i], ":")
+		if lastIdx < 0 {
+			return newError(types.PARSE_ERROR, "invalid rack value `%s`", rackPairs[i])
+		}
+
+		ns := rackPairs[i][:lastIdx]
+		rack := rackPairs[i][lastIdx+1:]
+
+		rackNo, err := strconv.Atoi(rack)
 		if err != nil {
 			return newErrorAndWrap(err, types.PARSE_ERROR)
 		}
-
-		ns, err := in.ReadString(':')
-		if err != nil {
-			return newErrorAndWrap(err, types.PARSE_ERROR)
-		}
-
-		for {
-			_, err = in.ReadString('_')
-			if err != nil {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			rackStr, err := in.ReadString('=')
-			if err != nil {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			rack, err := strconv.Atoi(rackStr[:len(rackStr)-1])
-			if err != nil {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			nodesList, err := in.ReadString(':')
-			if err != nil && err != io.EOF {
-				return newErrorAndWrap(err, types.PARSE_ERROR)
-			}
-
-			nodes := strings.Split(strings.Trim(nodesList, ":"), ",")
-			for i := range nodes {
-				if nodes[i] == nd.name {
-					racks[ns[:len(ns)-1]] = rack
-				}
-			}
-
-			if err == io.EOF {
-				break
-			}
-		}
+		racks[ns] = rackNo
 	}
 
 	nd.racks.Store(racks)


### PR DESCRIPTION
  Minor backported fix release.

- **Fixes**
  - [CLIENT-3156] Fix an issue where rack policy always returns the master node. Resolves #455
  - [CLIENT-3348] Parsing error during node rack update.

[CLIENT-3156]: https://aerospike.atlassian.net/browse/CLIENT-3156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3348]: https://aerospike.atlassian.net/browse/CLIENT-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ