### PR TITLE
CLIENT-3439 Provide user-level metrics for applications using Aerospike Database (Metrics v2)

### DIFF
--- a/aerospike_suite_test.go
+++ b/aerospike_suite_test.go
@@ -147,6 +147,9 @@ func initTestVars() {
 		p.ReplicaPolicy = as.MASTER_PROLES
 		client.SetDefaultPolicy(p)
 	}
+
+	// make sure the metrics code runs in all tests
+	client.EnableMetrics(nil)
 }
 
 func TestMain(m *testing.M) {

--- a/base_read_command.go
+++ b/base_read_command.go
@@ -98,3 +98,10 @@ func (cmd *baseReadCommand) Execute() Error {
 func (cmd *baseReadCommand) commandType() commandType {
 	return ttGet
 }
+
+func (cmd *baseReadCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace] = 1
+
+	return &response
+}

--- a/base_read_command.go
+++ b/base_read_command.go
@@ -99,7 +99,7 @@ func (cmd *baseReadCommand) commandType() commandType {
 	return ttGet
 }
 
-func (cmd *baseReadCommand) getNamespaces() *map[string]uint64 {
+func (cmd *baseReadCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/base_read_command.go
+++ b/base_read_command.go
@@ -15,6 +15,7 @@
 package aerospike
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/aerospike/aerospike-client-go/v8/types"
@@ -99,7 +100,7 @@ func (cmd *baseReadCommand) commandType() commandType {
 	return ttGet
 }
 
-func (cmd *baseReadCommand) getNamespaces() map[string]uint64 {
+func (cmd *baseReadCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/base_read_command.go
+++ b/base_read_command.go
@@ -99,9 +99,10 @@ func (cmd *baseReadCommand) commandType() commandType {
 	return ttGet
 }
 
-func (cmd *baseReadCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace] = 1
+func (cmd *baseReadCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *baseReadCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/base_write_command.go
+++ b/base_write_command.go
@@ -101,9 +101,10 @@ func (cmd *baseWriteCommand) parseHeader() (types.ResultCode, Error) {
 	return rp.resultCode, nil
 }
 
-func (cmd *baseWriteCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64)
-	response[cmd.key.namespace] = 1
+func (cmd *baseWriteCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *baseWriteCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/base_write_command.go
+++ b/base_write_command.go
@@ -14,7 +14,11 @@
 
 package aerospike
 
-import "github.com/aerospike/aerospike-client-go/v8/types"
+import (
+	"iter"
+
+	"github.com/aerospike/aerospike-client-go/v8/types"
+)
 
 // guarantee baseWriteCommand implements command interface
 var _ command = &baseWriteCommand{}
@@ -101,7 +105,7 @@ func (cmd *baseWriteCommand) parseHeader() (types.ResultCode, Error) {
 	return rp.resultCode, nil
 }
 
-func (cmd *baseWriteCommand) getNamespaces() map[string]uint64 {
+func (cmd *baseWriteCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/base_write_command.go
+++ b/base_write_command.go
@@ -101,7 +101,7 @@ func (cmd *baseWriteCommand) parseHeader() (types.ResultCode, Error) {
 	return rp.resultCode, nil
 }
 
-func (cmd *baseWriteCommand) getNamespaces() *map[string]uint64 {
+func (cmd *baseWriteCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/base_write_command.go
+++ b/base_write_command.go
@@ -100,3 +100,10 @@ func (cmd *baseWriteCommand) parseHeader() (types.ResultCode, Error) {
 
 	return rp.resultCode, nil
 }
+
+func (cmd *baseWriteCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64)
+	response[cmd.key.namespace] = 1
+
+	return &response
+}

--- a/batch_command.go
+++ b/batch_command.go
@@ -138,7 +138,7 @@ func (cmd *batchCommand) writeBuffer(ifc command) Error {
 	panic(unreachable)
 }
 
-func (cmd *batchCommand) getNamespaces() *map[string]uint64 {
+func (cmd *batchCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/batch_command.go
+++ b/batch_command.go
@@ -137,3 +137,11 @@ func (cmd *batchCommand) cloneBatchCommand(batch *batchNode) batcher {
 func (cmd *batchCommand) writeBuffer(ifc command) Error {
 	panic(unreachable)
 }
+
+func (cmd *batchCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
+
+func (cmd *batchCommand) getNamespace() *string {
+	return &cmd.namespace
+}

--- a/batch_command.go
+++ b/batch_command.go
@@ -14,6 +14,9 @@
 
 package aerospike
 
+import (
+	"iter"
+)
 type batcher interface {
 	command
 
@@ -138,7 +141,7 @@ func (cmd *batchCommand) writeBuffer(ifc command) Error {
 	panic(unreachable)
 }
 
-func (cmd *batchCommand) getNamespaces() map[string]uint64 {
+func (cmd *batchCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/batch_command_delete.go
+++ b/batch_command_delete.go
@@ -220,12 +220,12 @@ func (cmd *batchCommandDelete) generateBatchNodes(cluster *Cluster) ([]*batchNod
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandDelete) getNamespaces() *map[string]uint64 {
+func (cmd *batchCommandDelete) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
-	return &response
+	return response
 }
 
 func (cmd *batchCommandDelete) getNamespace() *string {

--- a/batch_command_delete.go
+++ b/batch_command_delete.go
@@ -81,11 +81,13 @@ func (cmd *batchCommandDelete) parseRecordResults(ifc command, receiveSize int) 
 			return false, err
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
+
 		generation := Buffer.BytesToUint32(cmd.dataBuffer, 6)
 		expiration := types.TTL(Buffer.BytesToUint32(cmd.dataBuffer, 10))
 		batchIndex := int(Buffer.BytesToUint32(cmd.dataBuffer, 14))
 		fieldCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 18))
 		opCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 20))
+
 		err := cmd.parseFieldsWrite(resultCode, fieldCount, cmd.keys[batchIndex])
 		if err != nil {
 			return false, err
@@ -110,6 +112,12 @@ func (cmd *batchCommandDelete) parseRecordResults(ifc command, receiveSize int) 
 		// If cmd is the end marker of the response, do not proceed further
 		if (info3 & _INFO3_LAST) == _INFO3_LAST {
 			return false, nil
+		}
+
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
 		}
 
 		if resultCode == 0 {
@@ -210,4 +218,12 @@ func (cmd *batchCommandDelete) Execute() Error {
 
 func (cmd *batchCommandDelete) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
+}
+
+func (cmd *batchCommandDelete) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.keys))
+	for _, key := range cmd.keys {
+		response[key.namespace]++
+	}
+	return &response
 }

--- a/batch_command_delete.go
+++ b/batch_command_delete.go
@@ -220,10 +220,14 @@ func (cmd *batchCommandDelete) generateBatchNodes(cluster *Cluster) ([]*batchNod
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandDelete) getNamespace() *map[string]uint64 {
+func (cmd *batchCommandDelete) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
 	return &response
+}
+
+func (cmd *batchCommandDelete) getNamespace() *string {
+	return nil
 }

--- a/batch_command_delete.go
+++ b/batch_command_delete.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	Buffer "github.com/aerospike/aerospike-client-go/v8/utils/buffer"
 )
@@ -220,14 +222,18 @@ func (cmd *batchCommandDelete) generateBatchNodes(cluster *Cluster) ([]*batchNod
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandDelete) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.keys))
-	for _, key := range cmd.keys {
-		response[key.namespace]++
-	}
-	return response
+func (cmd *batchCommandDelete) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchCommandDelete) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchCommandDelete) nsIter(yield func(string, uint64) bool) {
+	for _, key := range cmd.keys {
+		if !yield(key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/batch_command_exists.go
+++ b/batch_command_exists.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	Buffer "github.com/aerospike/aerospike-client-go/v8/utils/buffer"
 )
@@ -170,14 +172,18 @@ func (cmd *batchCommandExists) generateBatchNodes(cluster *Cluster) ([]*batchNod
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandExists) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.keys))
-	for _, key := range cmd.keys {
-		response[key.namespace]++
-	}
-	return response
+func (cmd *batchCommandExists) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchCommandExists) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchCommandExists) nsIter(yield func(string, uint64) bool) {
+	for _, key := range cmd.keys {
+		if !yield(key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/batch_command_exists.go
+++ b/batch_command_exists.go
@@ -170,12 +170,12 @@ func (cmd *batchCommandExists) generateBatchNodes(cluster *Cluster) ([]*batchNod
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandExists) getNamespaces() *map[string]uint64 {
+func (cmd *batchCommandExists) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
-	return &response
+	return response
 }
 
 func (cmd *batchCommandExists) getNamespace() *string {

--- a/batch_command_exists.go
+++ b/batch_command_exists.go
@@ -169,11 +169,14 @@ func (cmd *batchCommandExists) generateBatchNodes(cluster *Cluster) ([]*batchNod
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandExists) getNamespace() *map[string]uint64 {
+func (cmd *batchCommandExists) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
-
 	return &response
+}
+
+func (cmd *batchCommandExists) getNamespace() *string {
+	return nil
 }

--- a/batch_command_exists.go
+++ b/batch_command_exists.go
@@ -78,7 +78,8 @@ func (cmd *batchCommandExists) parseRecordResults(ifc command, receiveSize int) 
 		}
 
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
-
+		// generation := Buffer.BytesToUint32(cmd.dataBuffer, 6)
+		// expiration := types.TTL(Buffer.BytesToUint32(cmd.dataBuffer, 10))
 		batchIndex := int(Buffer.BytesToUint32(cmd.dataBuffer, 14))
 		fieldCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 18))
 		opCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 20))

--- a/batch_command_exists.go
+++ b/batch_command_exists.go
@@ -72,18 +72,17 @@ func (cmd *batchCommandExists) writeBuffer(ifc command) Error {
 func (cmd *batchCommandExists) parseRecordResults(ifc command, receiveSize int) (bool, Error) {
 	//Parse each message response and add it to the result array
 	cmd.dataOffset = 0
-
 	for cmd.dataOffset < receiveSize {
 		if err := cmd.readBytes(int(_MSG_REMAINING_HEADER_SIZE)); err != nil {
 			return false, err
 		}
 
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
-		// generation := Buffer.BytesToUint32(cmd.dataBuffer, 6)
-		// expiration := types.TTL(Buffer.BytesToUint32(cmd.dataBuffer, 10))
+
 		batchIndex := int(Buffer.BytesToUint32(cmd.dataBuffer, 14))
 		fieldCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 18))
 		opCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 20))
+
 		if len(cmd.keys) > batchIndex {
 			err := cmd.parseFieldsRead(fieldCount, cmd.keys[batchIndex])
 			if err != nil {
@@ -106,6 +105,12 @@ func (cmd *batchCommandExists) parseRecordResults(ifc command, receiveSize int) 
 		// If cmd is the end marker of the response, do not proceed further
 		if (int(info3) & _INFO3_LAST) == _INFO3_LAST {
 			return false, nil
+		}
+
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
 		}
 
 		if opCount > 0 {
@@ -162,4 +167,13 @@ func (cmd *batchCommandExists) Execute() Error {
 
 func (cmd *batchCommandExists) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
+}
+
+func (cmd *batchCommandExists) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.keys))
+	for _, key := range cmd.keys {
+		response[key.namespace]++
+	}
+
+	return &response
 }

--- a/batch_command_get.go
+++ b/batch_command_get.go
@@ -275,13 +275,13 @@ func (cmd *batchCommandGet) generateBatchNodes(cluster *Cluster) ([]*batchNode, 
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandGet) getNamespaces() *map[string]uint64 {
+func (cmd *batchCommandGet) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
 
-	return &response
+	return response
 }
 
 func (cmd *batchCommandGet) getNamespace() *string {

--- a/batch_command_get.go
+++ b/batch_command_get.go
@@ -15,6 +15,7 @@
 package aerospike
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/aerospike/aerospike-client-go/v8/types"
@@ -275,15 +276,18 @@ func (cmd *batchCommandGet) generateBatchNodes(cluster *Cluster) ([]*batchNode, 
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandGet) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.keys))
-	for _, key := range cmd.keys {
-		response[key.namespace]++
-	}
-
-	return response
+func (cmd *batchCommandGet) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchCommandGet) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchCommandGet) nsIter(yield func(string, uint64) bool) {
+	for _, key := range cmd.keys {
+		if !yield(key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/batch_command_get.go
+++ b/batch_command_get.go
@@ -275,11 +275,15 @@ func (cmd *batchCommandGet) generateBatchNodes(cluster *Cluster) ([]*batchNode, 
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandGet) getNamespace() *map[string]uint64 {
+func (cmd *batchCommandGet) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
 
 	return &response
+}
+
+func (cmd *batchCommandGet) getNamespace() *string {
+	return nil
 }

--- a/batch_command_get.go
+++ b/batch_command_get.go
@@ -116,23 +116,17 @@ func (cmd *batchCommandGet) writeBuffer(ifc command) Error {
 func (cmd *batchCommandGet) parseRecordResults(ifc command, receiveSize int) (bool, Error) {
 	//Parse each message response and add it to the result array
 	cmd.dataOffset = 0
-
 	for cmd.dataOffset < receiveSize {
 		if err := cmd.readBytes(int(_MSG_REMAINING_HEADER_SIZE)); err != nil {
 			return false, err
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
+
 		generation := Buffer.BytesToUint32(cmd.dataBuffer, 6)
 		expiration := types.TTL(Buffer.BytesToUint32(cmd.dataBuffer, 10))
 		batchIndex := int(Buffer.BytesToUint32(cmd.dataBuffer, 14))
 		fieldCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 18))
 		opCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 20))
-		if len(cmd.keys) > batchIndex {
-			err := cmd.parseFieldsRead(fieldCount, cmd.keys[batchIndex])
-			if err != nil {
-				return false, err
-			}
-		}
 
 		// The only valid server return codes are "ok" and "not found" and "filtered out".
 		// If other return codes are received, then abort the batch.
@@ -149,6 +143,12 @@ func (cmd *batchCommandGet) parseRecordResults(ifc command, receiveSize int) (bo
 		// If cmd is the end marker of the response, do not proceed further
 		if (info3 & _INFO3_LAST) == _INFO3_LAST {
 			return false, nil
+		}
+
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
 		}
 
 		var err Error
@@ -273,4 +273,13 @@ func (cmd *batchCommandGet) Execute() Error {
 
 func (cmd *batchCommandGet) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
+}
+
+func (cmd *batchCommandGet) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.keys))
+	for _, key := range cmd.keys {
+		response[key.namespace]++
+	}
+
+	return &response
 }

--- a/batch_command_operate.go
+++ b/batch_command_operate.go
@@ -162,6 +162,12 @@ func (cmd *batchCommandOperate) parseRecordResults(ifc command, receiveSize int)
 			continue
 		}
 
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		if resultCode == 0 {
 			if cmd.objects == nil {
 				rec, err := cmd.parseRecord(cmd.records[batchIndex].key(), opCount, generation, expiration)
@@ -300,4 +306,21 @@ func (cmd *batchCommandOperate) commandType() commandType {
 
 func (cmd *batchCommandOperate) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchOperateNodeListIfcRetry(cluster, cmd.policy, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch)
+}
+
+func (cmd *batchCommandOperate) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.records))
+	for _, br := range cmd.records {
+		switch br := br.(type) {
+		case *BatchRead:
+			response[br.Key.namespace]++
+		case *BatchWrite:
+			response[br.Key.namespace]++
+		case *BatchDelete:
+			response[br.Key.namespace]++
+		case *BatchUDF:
+			response[br.Key.namespace]++
+		}
+	}
+	return &response
 }

--- a/batch_command_operate.go
+++ b/batch_command_operate.go
@@ -308,21 +308,13 @@ func (cmd *batchCommandOperate) generateBatchNodes(cluster *Cluster) ([]*batchNo
 	return newBatchOperateNodeListIfcRetry(cluster, cmd.policy, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch)
 }
 
-func (cmd *batchCommandOperate) getNamespaces() *map[string]uint64 {
+func (cmd *batchCommandOperate) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.records))
 	for _, br := range cmd.records {
-		switch br := br.(type) {
-		case *BatchRead:
-			response[br.Key.namespace]++
-		case *BatchWrite:
-			response[br.Key.namespace]++
-		case *BatchDelete:
-			response[br.Key.namespace]++
-		case *BatchUDF:
-			response[br.Key.namespace]++
-		}
+		response[br.key().namespace]++
 	}
-	return &response
+
+	return response
 }
 
 func (cmd *batchCommandOperate) getNamespace() *string {

--- a/batch_command_operate.go
+++ b/batch_command_operate.go
@@ -15,6 +15,7 @@
 package aerospike
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/aerospike/aerospike-client-go/v8/types"
@@ -308,15 +309,18 @@ func (cmd *batchCommandOperate) generateBatchNodes(cluster *Cluster) ([]*batchNo
 	return newBatchOperateNodeListIfcRetry(cluster, cmd.policy, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch)
 }
 
-func (cmd *batchCommandOperate) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.records))
-	for _, br := range cmd.records {
-		response[br.key().namespace]++
-	}
-
-	return response
+func (cmd *batchCommandOperate) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchCommandOperate) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchCommandOperate) nsIter(yield func(string, uint64) bool) {
+	for _, br := range cmd.records {
+		if !yield(br.key().namespace, 1) {
+			return
+		}
+	}
 }

--- a/batch_command_operate.go
+++ b/batch_command_operate.go
@@ -308,7 +308,7 @@ func (cmd *batchCommandOperate) generateBatchNodes(cluster *Cluster) ([]*batchNo
 	return newBatchOperateNodeListIfcRetry(cluster, cmd.policy, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch)
 }
 
-func (cmd *batchCommandOperate) getNamespace() *map[string]uint64 {
+func (cmd *batchCommandOperate) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.records))
 	for _, br := range cmd.records {
 		switch br := br.(type) {
@@ -323,4 +323,8 @@ func (cmd *batchCommandOperate) getNamespace() *map[string]uint64 {
 		}
 	}
 	return &response
+}
+
+func (cmd *batchCommandOperate) getNamespace() *string {
+	return nil
 }

--- a/batch_command_udf.go
+++ b/batch_command_udf.go
@@ -90,14 +90,22 @@ func (cmd *batchCommandUDF) parseRecordResults(ifc command, receiveSize int) (bo
 			return false, err
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
+
 		generation := Buffer.BytesToUint32(cmd.dataBuffer, 6)
 		expiration := types.TTL(Buffer.BytesToUint32(cmd.dataBuffer, 10))
 		batchIndex := int(Buffer.BytesToUint32(cmd.dataBuffer, 14))
 		fieldCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 18))
 		opCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 20))
 		err := cmd.parseFieldsWrite(resultCode, fieldCount, cmd.keys[batchIndex])
+
 		if err != nil {
 			return false, err
+		}
+
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
 		}
 
 		// The only valid server return codes are "ok" and "not found" and "filtered out".
@@ -220,4 +228,12 @@ func (cmd *batchCommandUDF) Execute() Error {
 
 func (cmd *batchCommandUDF) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
+}
+
+func (cmd *batchCommandUDF) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.keys))
+	for _, key := range cmd.keys {
+		response[key.namespace]++
+	}
+	return &response
 }

--- a/batch_command_udf.go
+++ b/batch_command_udf.go
@@ -230,10 +230,14 @@ func (cmd *batchCommandUDF) generateBatchNodes(cluster *Cluster) ([]*batchNode, 
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandUDF) getNamespace() *map[string]uint64 {
+func (cmd *batchCommandUDF) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
 	return &response
+}
+
+func (cmd *batchCommandUDF) getNamespace() *string {
+	return nil
 }

--- a/batch_command_udf.go
+++ b/batch_command_udf.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	Buffer "github.com/aerospike/aerospike-client-go/v8/utils/buffer"
 )
@@ -230,14 +232,18 @@ func (cmd *batchCommandUDF) generateBatchNodes(cluster *Cluster) ([]*batchNode, 
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandUDF) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.keys))
-	for _, key := range cmd.keys {
-		response[key.namespace]++
-	}
-	return response
+func (cmd *batchCommandUDF) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchCommandUDF) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchCommandUDF) nsIter(yield func(string, uint64) bool) {
+	for _, key := range cmd.keys {
+		if !yield(key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/batch_command_udf.go
+++ b/batch_command_udf.go
@@ -230,12 +230,12 @@ func (cmd *batchCommandUDF) generateBatchNodes(cluster *Cluster) ([]*batchNode, 
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, nil, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *batchCommandUDF) getNamespaces() *map[string]uint64 {
+func (cmd *batchCommandUDF) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.namespace]++
 	}
-	return &response
+	return response
 }
 
 func (cmd *batchCommandUDF) getNamespace() *string {

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -255,10 +255,14 @@ func (cmd *batchIndexCommandGet) parseRecord(key *Key, opCount int, generation, 
 	return newRecord(cmd.node, key, bins, generation, expiration), nil
 }
 
-func (cmd *batchIndexCommandGet) getNamespace() *map[string]uint64 {
+func (cmd *batchIndexCommandGet) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.records))
 	for _, br := range cmd.records {
 		response[br.Key.namespace]++
 	}
 	return &response
+}
+
+func (cmd *batchIndexCommandGet) getNamespace() *string {
+	return nil
 }

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	Buffer "github.com/aerospike/aerospike-client-go/v8/utils/buffer"
 )
@@ -255,14 +257,18 @@ func (cmd *batchIndexCommandGet) parseRecord(key *Key, opCount int, generation, 
 	return newRecord(cmd.node, key, bins, generation, expiration), nil
 }
 
-func (cmd *batchIndexCommandGet) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.records))
-	for _, br := range cmd.records {
-		response[br.Key.namespace]++
-	}
-	return response
+func (cmd *batchIndexCommandGet) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchIndexCommandGet) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchIndexCommandGet) nsIter(yield func(string, uint64) bool) {
+	for _, br := range cmd.records {
+		if !yield(br.Key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -255,12 +255,12 @@ func (cmd *batchIndexCommandGet) parseRecord(key *Key, opCount int, generation, 
 	return newRecord(cmd.node, key, bins, generation, expiration), nil
 }
 
-func (cmd *batchIndexCommandGet) getNamespaces() *map[string]uint64 {
+func (cmd *batchIndexCommandGet) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.records))
 	for _, br := range cmd.records {
 		response[br.Key.namespace]++
 	}
-	return &response
+	return response
 }
 
 func (cmd *batchIndexCommandGet) getNamespace() *string {

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -132,6 +132,12 @@ func (cmd *batchIndexCommandGet) parseRecordResults(ifc command, receiveSize int
 			return false, err
 		}
 
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		if resultCode != 0 {
 			if resultCode == types.FILTERED_OUT {
 				cmd.filteredOutCnt++
@@ -247,4 +253,12 @@ func (cmd *batchIndexCommandGet) parseRecord(key *Key, opCount int, generation, 
 	}
 
 	return newRecord(cmd.node, key, bins, generation, expiration), nil
+}
+
+func (cmd *batchIndexCommandGet) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.records))
+	for _, br := range cmd.records {
+		response[br.Key.namespace]++
+	}
+	return &response
 }

--- a/bench_apply_metrics_test.go
+++ b/bench_apply_metrics_test.go
@@ -1,0 +1,198 @@
+package aerospike
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	amap "github.com/aerospike/aerospike-client-go/v8/internal/atomic/map"
+	"github.com/aerospike/aerospike-client-go/v8/types"
+)
+
+// fakeCommand implements the minimal parts of command used by applyDetailedMetricsDataSizeAndLatency.
+type fakeCommand struct {
+	namespace string
+	ct        commandType
+}
+
+func (fc fakeCommand) getNamespace() *map[string]uint64 {
+	result := make(map[string]uint64, 1)
+	result[fc.namespace]++
+
+	return &result
+}
+
+func (fc fakeCommand) commandType() commandType {
+	return fc.ct
+}
+
+func (fn fakeCommand) Execute() Error {
+	return nil
+}
+
+func (fn fakeCommand) getPolicy(ifc command) Policy {
+	return nil
+}
+
+func (fn fakeCommand) writeBuffer(ifc command) Error {
+	return nil
+}
+
+func (fn fakeCommand) getNode(ifc command) (*Node, Error) {
+	return nil, nil
+}
+
+func (fn fakeCommand) getConnection(policy Policy) (*Connection, Error) {
+	return nil, nil
+}
+
+func (fn fakeCommand) putConnection(conn *Connection) {
+
+}
+
+func (fn fakeCommand) parseResult(ifc command, conn *Connection) Error {
+	return nil
+}
+
+func (fn fakeCommand) parseRecordResults(ifc command, receiveSize int) (bool, Error) {
+	return false, nil
+}
+
+func (fn fakeCommand) prepareRetry(ifc command, isTimeout bool) bool {
+	return false
+}
+
+func (fn fakeCommand) isRead() bool {
+	return false
+}
+
+func (fn fakeCommand) onInDoubt() {
+
+}
+
+func (fn fakeCommand) execute(ifc command) Error {
+	return nil
+}
+
+func (fn fakeCommand) executeIter(ifc command, iter int) Error {
+	return nil
+}
+
+func (fn fakeCommand) executeAt(ifc command, policy *BasePolicy, deadline time.Time, iterations int) Error {
+	return nil
+}
+
+func (fn fakeCommand) canPutConnBack() bool {
+	return false
+}
+
+func newStub() (*baseCommand, fakeCommand) {
+	mp := DefaultMetricsPolicy()
+	nodeStats := newNodeStats(mp)
+	me.Store(true)
+	// setup a fake node and baseCommand with metrics enabled.
+	node := &Node{
+		cluster: &Cluster{
+			metricsEnabled: me,
+		},
+		stats: *nodeStats,
+	}
+
+	// baseCommand to be used for the benchmark.
+	cmd := &baseCommand{
+		node: node,
+	}
+
+	// Use a non-empty namespace and a command type (for example, ttGet).
+	fcmd := fakeCommand{
+		namespace: "test",
+		ct:        ttGet,
+	}
+	return cmd, fcmd
+}
+
+var me atomic.Bool
+
+func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
+	cmd, fcmd := newStub()
+
+	// bytesSent value to simulate.
+	bytesReceived := 100
+	bytesSent := 100
+	cmd.applyDetailedMetricsDataSizeAndLatency(fcmd, bytesSent, bytesReceived, time.Now())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Call the function under test.
+		cmd.applyDetailedMetricsDataSizeAndLatency(fcmd, bytesSent, bytesReceived, time.Now())
+	}
+}
+
+func BenchmarkApplyDetailedConnectionAq(b *testing.B) {
+	cmd, fcmd := newStub()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Call the function under test.
+		cmd.applyDetailedMetricsConnectionAq(fcmd, time.Now())
+	}
+}
+
+func BenchmarkApplyDetailedParsing(b *testing.B) {
+	cmd, fcmd := newStub()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Call the function under test.
+		cmd.applyDetailedMetricsParsing(fcmd, time.Now())
+	}
+}
+
+func BenchmarkCommandMergeCommandResultCodeMetrics(b *testing.B) {
+	mp := DefaultMetricsPolicy()
+	targetNodeStats := newNodeStats(mp)
+	sourceNodeStats := newNodeStats(mp)
+
+	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "test", ct: ttGet}, types.ResultCode(0))
+	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "testTwo", ct: ttPut}, types.ResultCode(0))
+	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "testThree", ct: ttExists}, types.ResultCode(0))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		targetNodeStats.mergeCommandResultCodeMetric(sourceNodeStats)
+	}
+}
+
+func BenchmarkCommandMergeDetailMetrics(b *testing.B) {
+	policy := DefaultMetricsPolicy()
+	sourceNodeStats := newNodeStats(policy)
+	targetNodeStats := newNodeStats(policy)
+
+	b.StopTimer()
+	operations := []commandType{ttExists}
+
+	for _, operation := range operations {
+		sourceNodeStats.DetailedMetrics.UpdateOrInsertFn("test", func(inner *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+			// Insert metrics for ttGet
+			inner.UpdateOrInsertFn(operation, func(cm *commandMetric) *commandMetric {
+				// Simulate metrics data
+				cm.Parsing.Add(uint64(1))
+				cm.BytesSent.Add(uint64(1))
+				cm.ConnectionAq.Add(uint64(1))
+				cm.Latency.Add(uint64(1))
+				return cm
+			}, func() *commandMetric {
+				return sourceNodeStats.newCommandMetric()
+			})
+			return inner
+		}, func() *amap.Map[commandType, *commandMetric] {
+			return amap.NewWithValue(operation, sourceNodeStats.newCommandMetric())
+		})
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		// Merge incoming detailed metrics into target.
+		targetNodeStats.mergeDetailedMetrics(sourceNodeStats)
+	}
+}

--- a/bench_apply_metrics_test.go
+++ b/bench_apply_metrics_test.go
@@ -1,6 +1,7 @@
 package aerospike
 
 import (
+	"iter"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,13 +17,16 @@ type fakeCommand struct {
 	ct         commandType
 }
 
-func (fc *fakeCommand) getNamespaces() map[string]uint64 {
-	result := make(map[string]uint64, len(fc.namespaces))
-	for _, namespace := range fc.namespaces {
-		result[namespace]++
-	}
+func (fc *fakeCommand) getNamespaces() iter.Seq2[string, uint64] {
+	return fc.nsIter
+}
 
-	return result
+func (fc *fakeCommand) nsIter(yield func(string, uint64) bool) {
+	for i := range fc.namespaces {
+		if !yield(fc.namespaces[i], 1) {
+			return
+		}
+	}
 }
 
 func (fc *fakeCommand) getNamespace() *string {
@@ -150,7 +154,9 @@ var me atomic.Bool
 func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
 	b.StopTimer()
 	fcmd := newStubWithNamespaces()
-	//fcmd := newFakeCmdSingle()
+	// fcmd := newFakeCmdSingle()
+
+	now := time.Now()
 
 	// bytesSent value to simulate.
 	bytesSent := 100
@@ -159,7 +165,7 @@ func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
-		fcmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(fcmd, bytesSent, time.Now())
+		fcmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(fcmd, bytesSent, now)
 	}
 }
 
@@ -316,7 +322,7 @@ type fakeCmdSingle struct {
 	fakeCommand
 }
 
-func (fc *fakeCmdSingle) getNamespaces() map[string]uint64 {
+func (fc *fakeCmdSingle) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/bench_apply_metrics_test.go
+++ b/bench_apply_metrics_test.go
@@ -155,7 +155,7 @@ func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
-		cmd.applyDetailedMetricsDataSizeAndLatency(fcmd, bytesSent, time.Now())
+		cmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(fcmd, bytesSent, time.Now())
 	}
 }
 

--- a/bench_apply_metrics_test.go
+++ b/bench_apply_metrics_test.go
@@ -15,11 +15,15 @@ type fakeCommand struct {
 	ct        commandType
 }
 
-func (fc fakeCommand) getNamespace() *map[string]uint64 {
+func (fc fakeCommand) getNamespaces() *map[string]uint64 {
 	result := make(map[string]uint64, 1)
 	result[fc.namespace]++
 
 	return &result
+}
+
+func (fc fakeCommand) getNamespace() *string {
+	return nil
 }
 
 func (fc fakeCommand) commandType() commandType {
@@ -194,5 +198,67 @@ func BenchmarkCommandMergeDetailMetrics(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Merge incoming detailed metrics into target.
 		targetNodeStats.mergeDetailedMetrics(sourceNodeStats)
+	}
+}
+
+func BenchmarkCloneDetailedMetrics(b *testing.B) {
+	policy := DefaultMetricsPolicy()
+
+	ns := newNodeStats(policy)
+
+	const testNamespace = "test"
+	sampleMap := amap.New[commandType, *commandMetric](0)
+	sampleMap.UpdateOrInsertFn(ttGet, func(old *commandMetric) *commandMetric {
+		return old
+	}, func() *commandMetric {
+		return ns.newCommandMetric()
+	})
+	// Insert the sample map under the test namespace.
+	ns.DetailedMetrics.UpdateOrInsertFn(testNamespace, func(old *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+		return old
+	}, func() *amap.Map[commandType, *commandMetric] {
+		return sampleMap
+	})
+
+	now := time.Now()
+	ns.DetailedMetrics.Get(testNamespace).Get(ttGet).Latency.Add(uint64(now.UnixNano()))
+	ns.DetailedMetrics.Get(testNamespace).Get(ttGet).BytesSent.Add(1024)
+	ns.DetailedMetrics.Get(testNamespace).Get(ttGet).Parsing.Add(uint64(now.UnixNano()))
+	ns.DetailedMetrics.Get(testNamespace).Get(ttGet).ConnectionAq.Add(5)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cloned := ns.cloneDetailedMetrics()
+		// Use cloned in some trivial way to prevent compiler optimizations.
+		if cloned == nil || cloned.Length() == 0 {
+			b.Fatal("cloned DetailedMetrics is nil or empty")
+		}
+	}
+}
+
+func BenchmarkCloneAndResetDetailedResultCodeCounts(b *testing.B) {
+	policy := DefaultMetricsPolicy()
+	ns := newNodeStats(policy)
+
+	ns.DetailedResultCodeCounts.UpdateOrInsertFn("test", func(inner *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+		inner.UpdateOrInsertFn(ttGet, func(metric *commandResultCodeMetric) *commandResultCodeMetric {
+			metric.ResultCodeCounts.UpdateOrInsert(types.ResultCode(0), func(val uint64) uint64 {
+				return val + 1
+			}, 0)
+			return metric
+		}, func() *commandResultCodeMetric {
+			return ns.newCommandResultCodeMetricWithValue(types.ResultCode(0))
+		})
+		return inner
+	}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+		return amap.NewWithValue(ttGet, ns.newCommandResultCodeMetricWithValue(types.ResultCode(0)))
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cloned := ns.cloneAndResetDetailedResultCodeCounts()
+		if cloned.Length() == 0 {
+			b.Fatal("cloned DetailedResultCodeCounts is empty")
+		}
 	}
 }

--- a/bench_apply_metrics_test.go
+++ b/bench_apply_metrics_test.go
@@ -9,15 +9,17 @@ import (
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
-// fakeCommand implements the minimal parts of command used by applyDetailedMetricsDataSizeAndLatency.
 type fakeCommand struct {
-	namespace string
-	ct        commandType
+	namespace  string
+	namespaces []string
+	ct         commandType
 }
 
 func (fc fakeCommand) getNamespaces() *map[string]uint64 {
-	result := make(map[string]uint64, 1)
-	result[fc.namespace]++
+	result := make(map[string]uint64, 0)
+	for _, namespace := range fc.namespaces {
+		result[namespace]++
+	}
 
 	return &result
 }
@@ -115,27 +117,55 @@ func newStub() (*baseCommand, fakeCommand) {
 	return cmd, fcmd
 }
 
+func newStubWithNamespaces() (*baseCommand, fakeCommand) {
+	mp := DefaultMetricsPolicy()
+	nodeStats := newNodeStats(mp)
+	me.Store(true)
+	// setup a fake node and baseCommand with metrics enabled.
+	node := &Node{
+		cluster: &Cluster{
+			metricsEnabled: me,
+		},
+		stats: *nodeStats,
+	}
+
+	// baseCommand to be used for the benchmark.
+	cmd := &baseCommand{
+		node: node,
+	}
+
+	// Use a non-empty namespace and a command type (for example, ttGet).
+	fcmd := fakeCommand{
+		namespaces: []string{"test", "testTwo", "testThree", "testFour", "testFive", "testSix"},
+		ct:         ttGet,
+	}
+	return cmd, fcmd
+}
+
 var me atomic.Bool
 
 func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
-	cmd, fcmd := newStub()
+	b.StopTimer()
+	cmd, fcmd := newStubWithNamespaces()
 
 	// bytesSent value to simulate.
-	bytesReceived := 100
 	bytesSent := 100
-	cmd.applyDetailedMetricsDataSizeAndLatency(fcmd, bytesSent, bytesReceived, time.Now())
-
+	b.StartTimer()
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
-		cmd.applyDetailedMetricsDataSizeAndLatency(fcmd, bytesSent, bytesReceived, time.Now())
+		cmd.applyDetailedMetricsDataSizeAndLatency(fcmd, bytesSent, time.Now())
 	}
 }
 
 func BenchmarkApplyDetailedConnectionAq(b *testing.B) {
+	b.StopTimer()
 	cmd, fcmd := newStub()
 
+	b.StartTimer()
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
 		cmd.applyDetailedMetricsConnectionAq(fcmd, time.Now())
@@ -143,9 +173,12 @@ func BenchmarkApplyDetailedConnectionAq(b *testing.B) {
 }
 
 func BenchmarkApplyDetailedParsing(b *testing.B) {
+	b.StopTimer()
 	cmd, fcmd := newStub()
 
+	b.StartTimer()
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
 		cmd.applyDetailedMetricsParsing(fcmd, time.Now())
@@ -153,6 +186,7 @@ func BenchmarkApplyDetailedParsing(b *testing.B) {
 }
 
 func BenchmarkCommandMergeCommandResultCodeMetrics(b *testing.B) {
+	b.StopTimer()
 	mp := DefaultMetricsPolicy()
 	targetNodeStats := newNodeStats(mp)
 	sourceNodeStats := newNodeStats(mp)
@@ -161,13 +195,16 @@ func BenchmarkCommandMergeCommandResultCodeMetrics(b *testing.B) {
 	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "testTwo", ct: ttPut}, types.ResultCode(0))
 	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "testThree", ct: ttExists}, types.ResultCode(0))
 
+	b.StartTimer()
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		targetNodeStats.mergeCommandResultCodeMetric(sourceNodeStats)
 	}
 }
 
 func BenchmarkCommandMergeDetailMetrics(b *testing.B) {
+	b.StopTimer()
 	policy := DefaultMetricsPolicy()
 	sourceNodeStats := newNodeStats(policy)
 	targetNodeStats := newNodeStats(policy)
@@ -195,6 +232,8 @@ func BenchmarkCommandMergeDetailMetrics(b *testing.B) {
 	}
 
 	b.StartTimer()
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Merge incoming detailed metrics into target.
 		targetNodeStats.mergeDetailedMetrics(sourceNodeStats)
@@ -202,6 +241,7 @@ func BenchmarkCommandMergeDetailMetrics(b *testing.B) {
 }
 
 func BenchmarkCloneDetailedMetrics(b *testing.B) {
+	b.StopTimer()
 	policy := DefaultMetricsPolicy()
 
 	ns := newNodeStats(policy)
@@ -226,7 +266,9 @@ func BenchmarkCloneDetailedMetrics(b *testing.B) {
 	ns.DetailedMetrics.Get(testNamespace).Get(ttGet).Parsing.Add(uint64(now.UnixNano()))
 	ns.DetailedMetrics.Get(testNamespace).Get(ttGet).ConnectionAq.Add(5)
 
+	b.StartTimer()
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		cloned := ns.cloneDetailedMetrics()
 		// Use cloned in some trivial way to prevent compiler optimizations.
@@ -237,9 +279,9 @@ func BenchmarkCloneDetailedMetrics(b *testing.B) {
 }
 
 func BenchmarkCloneAndResetDetailedResultCodeCounts(b *testing.B) {
+	b.StopTimer()
 	policy := DefaultMetricsPolicy()
 	ns := newNodeStats(policy)
-
 	ns.DetailedResultCodeCounts.UpdateOrInsertFn("test", func(inner *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
 		inner.UpdateOrInsertFn(ttGet, func(metric *commandResultCodeMetric) *commandResultCodeMetric {
 			metric.ResultCodeCounts.UpdateOrInsert(types.ResultCode(0), func(val uint64) uint64 {
@@ -254,7 +296,9 @@ func BenchmarkCloneAndResetDetailedResultCodeCounts(b *testing.B) {
 		return amap.NewWithValue(ttGet, ns.newCommandResultCodeMetricWithValue(types.ResultCode(0)))
 	})
 
+	b.StartTimer()
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		cloned := ns.cloneAndResetDetailedResultCodeCounts()
 		if cloned.Length() == 0 {

--- a/bench_apply_metrics_test.go
+++ b/bench_apply_metrics_test.go
@@ -10,89 +10,90 @@ import (
 )
 
 type fakeCommand struct {
+	baseCommand
 	namespace  string
 	namespaces []string
 	ct         commandType
 }
 
-func (fc fakeCommand) getNamespaces() *map[string]uint64 {
-	result := make(map[string]uint64, 0)
+func (fc *fakeCommand) getNamespaces() map[string]uint64 {
+	result := make(map[string]uint64, len(fc.namespaces))
 	for _, namespace := range fc.namespaces {
 		result[namespace]++
 	}
 
-	return &result
+	return result
 }
 
-func (fc fakeCommand) getNamespace() *string {
+func (fc *fakeCommand) getNamespace() *string {
 	return nil
 }
 
-func (fc fakeCommand) commandType() commandType {
+func (fc *fakeCommand) commandType() commandType {
 	return fc.ct
 }
 
-func (fn fakeCommand) Execute() Error {
+func (fn *fakeCommand) Execute() Error {
 	return nil
 }
 
-func (fn fakeCommand) getPolicy(ifc command) Policy {
+func (fn *fakeCommand) getPolicy(ifc command) Policy {
 	return nil
 }
 
-func (fn fakeCommand) writeBuffer(ifc command) Error {
+func (fn *fakeCommand) writeBuffer(ifc command) Error {
 	return nil
 }
 
-func (fn fakeCommand) getNode(ifc command) (*Node, Error) {
+func (fn *fakeCommand) getNode(ifc command) (*Node, Error) {
 	return nil, nil
 }
 
-func (fn fakeCommand) getConnection(policy Policy) (*Connection, Error) {
+func (fn *fakeCommand) getConnection(policy Policy) (*Connection, Error) {
 	return nil, nil
 }
 
-func (fn fakeCommand) putConnection(conn *Connection) {
+func (fn *fakeCommand) putConnection(conn *Connection) {
 
 }
 
-func (fn fakeCommand) parseResult(ifc command, conn *Connection) Error {
+func (fn *fakeCommand) parseResult(ifc command, conn *Connection) Error {
 	return nil
 }
 
-func (fn fakeCommand) parseRecordResults(ifc command, receiveSize int) (bool, Error) {
+func (fn *fakeCommand) parseRecordResults(ifc command, receiveSize int) (bool, Error) {
 	return false, nil
 }
 
-func (fn fakeCommand) prepareRetry(ifc command, isTimeout bool) bool {
+func (fn *fakeCommand) prepareRetry(ifc command, isTimeout bool) bool {
 	return false
 }
 
-func (fn fakeCommand) isRead() bool {
+func (fn *fakeCommand) isRead() bool {
 	return false
 }
 
-func (fn fakeCommand) onInDoubt() {
+func (fn *fakeCommand) onInDoubt() {
 
 }
 
-func (fn fakeCommand) execute(ifc command) Error {
+func (fn *fakeCommand) execute(ifc command) Error {
 	return nil
 }
 
-func (fn fakeCommand) executeIter(ifc command, iter int) Error {
+func (fn *fakeCommand) executeIter(ifc command, iter int) Error {
 	return nil
 }
 
-func (fn fakeCommand) executeAt(ifc command, policy *BasePolicy, deadline time.Time, iterations int) Error {
+func (fn *fakeCommand) executeAt(ifc command, policy *BasePolicy, deadline time.Time, iterations int) Error {
 	return nil
 }
 
-func (fn fakeCommand) canPutConnBack() bool {
+func (fn *fakeCommand) canPutConnBack() bool {
 	return false
 }
 
-func newStub() (*baseCommand, fakeCommand) {
+func newStub() *fakeCommand {
 	mp := DefaultMetricsPolicy()
 	nodeStats := newNodeStats(mp)
 	me.Store(true)
@@ -105,19 +106,20 @@ func newStub() (*baseCommand, fakeCommand) {
 	}
 
 	// baseCommand to be used for the benchmark.
-	cmd := &baseCommand{
+	cmd := baseCommand{
 		node: node,
 	}
 
 	// Use a non-empty namespace and a command type (for example, ttGet).
 	fcmd := fakeCommand{
-		namespace: "test",
-		ct:        ttGet,
+		baseCommand: cmd,
+		namespace:   "test",
+		ct:          ttGet,
 	}
-	return cmd, fcmd
+	return &fcmd
 }
 
-func newStubWithNamespaces() (*baseCommand, fakeCommand) {
+func newStubWithNamespaces() *fakeCommand {
 	mp := DefaultMetricsPolicy()
 	nodeStats := newNodeStats(mp)
 	me.Store(true)
@@ -130,23 +132,25 @@ func newStubWithNamespaces() (*baseCommand, fakeCommand) {
 	}
 
 	// baseCommand to be used for the benchmark.
-	cmd := &baseCommand{
+	cmd := baseCommand{
 		node: node,
 	}
 
 	// Use a non-empty namespace and a command type (for example, ttGet).
 	fcmd := fakeCommand{
-		namespaces: []string{"test", "testTwo", "testThree", "testFour", "testFive", "testSix"},
-		ct:         ttGet,
+		baseCommand: cmd,
+		namespaces:  []string{"test", "testTwo", "testThree", "testFour", "testFive", "testSix"},
+		ct:          ttGet,
 	}
-	return cmd, fcmd
+	return &fcmd
 }
 
 var me atomic.Bool
 
 func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
 	b.StopTimer()
-	cmd, fcmd := newStubWithNamespaces()
+	fcmd := newStubWithNamespaces()
+	//fcmd := newFakeCmdSingle()
 
 	// bytesSent value to simulate.
 	bytesSent := 100
@@ -155,33 +159,34 @@ func BenchmarkApplyDetailedMetricsDataSizeAndLatency(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
-		cmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(fcmd, bytesSent, time.Now())
+		fcmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(fcmd, bytesSent, time.Now())
 	}
 }
 
 func BenchmarkApplyDetailedConnectionAq(b *testing.B) {
 	b.StopTimer()
-	cmd, fcmd := newStub()
+	fcmd := newStub()
 
 	b.StartTimer()
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
-		cmd.applyDetailedMetricsConnectionAq(fcmd, time.Now())
+		fcmd.applyDetailedMetricsConnectionAq(fcmd, time.Now())
 	}
 }
 
 func BenchmarkApplyDetailedParsing(b *testing.B) {
 	b.StopTimer()
-	cmd, fcmd := newStub()
+	fcmd := newStub()
 
 	b.StartTimer()
 	b.ResetTimer()
 	b.ReportAllocs()
+	bytesReceived := 100
 	for i := 0; i < b.N; i++ {
 		// Call the function under test.
-		cmd.applyDetailedMetricsParsing(fcmd, time.Now())
+		fcmd.applyDetailedMetricsParsing(fcmd, time.Now(), int64(bytesReceived))
 	}
 }
 
@@ -191,9 +196,9 @@ func BenchmarkCommandMergeCommandResultCodeMetrics(b *testing.B) {
 	targetNodeStats := newNodeStats(mp)
 	sourceNodeStats := newNodeStats(mp)
 
-	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "test", ct: ttGet}, types.ResultCode(0))
-	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "testTwo", ct: ttPut}, types.ResultCode(0))
-	sourceNodeStats.updateOrInsert(fakeCommand{namespace: "testThree", ct: ttExists}, types.ResultCode(0))
+	sourceNodeStats.updateOrInsert(&fakeCommand{namespace: "test", ct: ttGet}, types.ResultCode(0))
+	sourceNodeStats.updateOrInsert(&fakeCommand{namespace: "testTwo", ct: ttPut}, types.ResultCode(0))
+	sourceNodeStats.updateOrInsert(&fakeCommand{namespace: "testThree", ct: ttExists}, types.ResultCode(0))
 
 	b.StartTimer()
 	b.ResetTimer()
@@ -304,5 +309,23 @@ func BenchmarkCloneAndResetDetailedResultCodeCounts(b *testing.B) {
 		if cloned.Length() == 0 {
 			b.Fatal("cloned DetailedResultCodeCounts is empty")
 		}
+	}
+}
+
+type fakeCmdSingle struct {
+	fakeCommand
+}
+
+func (fc *fakeCmdSingle) getNamespaces() map[string]uint64 {
+	return nil
+}
+
+func (fc *fakeCmdSingle) getNamespace() *string {
+	return &fc.namespace
+}
+
+func newFakeCmdSingle() *fakeCmdSingle {
+	return &fakeCmdSingle{
+		fakeCommand: *newStub(),
 	}
 }

--- a/bench_map_test.go
+++ b/bench_map_test.go
@@ -1,0 +1,49 @@
+package aerospike
+
+import (
+	"testing"
+
+	amap "github.com/aerospike/aerospike-client-go/v8/internal/atomic/map"
+)
+
+func BenchmarkCloneMap(b *testing.B) {
+	m := amap.New[commandType, int](1)
+	commands := []commandType{ttPut, ttBatchRead, ttDelete, ttGet, ttQuery, ttScan, ttExists, ttNone, ttUDF, ttBatchRead, ttBatchWrite}
+	for i := 0; i < 20000; i++ {
+		command := commands[i%len(commands)]
+		m.Set(command, i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.CloneMap()
+	}
+}
+
+func BenchmarkCloneAndResetMap(b *testing.B) {
+	m := amap.New[commandType, int](1)
+	commands := []commandType{ttPut, ttBatchRead, ttDelete, ttGet, ttQuery, ttScan, ttExists, ttNone, ttUDF, ttBatchRead, ttBatchWrite}
+	for i := 0; i < 20000; i++ {
+		command := commands[i%len(commands)]
+		m.Set(command, i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.CloneAndResetMap()
+	}
+}
+
+func BenchmarkClone(b *testing.B) {
+	m := amap.New[commandType, int](1)
+	commands := []commandType{ttPut, ttBatchRead, ttDelete, ttGet, ttQuery, ttScan, ttExists, ttNone, ttUDF, ttBatchRead, ttBatchWrite}
+	for i := 0; i < 20000; i++ {
+		command := commands[i%len(commands)]
+		m.Set(command, i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Clone()
+	}
+}

--- a/client.go
+++ b/client.go
@@ -2009,11 +2009,13 @@ func (clnt *Client) DisableMetrics() {
 func (clnt *Client) Stats() (map[string]any, Error) {
 	resStats := clnt.cluster.statsCopy()
 
-	clusterStats := *newNodeStats(clnt.cluster.MetricsPolicy())
+	mp := clnt.cluster.MetricsPolicy()
+	clusterStats := *newNodeStats(mp)
 	for _, stats := range resStats {
 		clusterStats.aggregate(&stats)
 	}
 
+	clusterStats.StatLabels = clnt.cluster.getNodeLabels(mp)
 	resStats["cluster-aggregated-stats"] = clusterStats
 
 	b, err := json.Marshal(resStats)

--- a/client_policy.go
+++ b/client_policy.go
@@ -175,6 +175,8 @@ type ClientPolicy struct {
 	// retained despite connection failures.
 	SeedOnlyCluster bool // = false
 
+	// Application id is used to identify application so that client operations can be correlated
+	// with server side metrics.
 	ApplicationId string
 }
 

--- a/client_policy.go
+++ b/client_policy.go
@@ -174,6 +174,8 @@ type ClientPolicy struct {
 	// Peers nodes for the cluster are not discovered and seed nodes are
 	// retained despite connection failures.
 	SeedOnlyCluster bool // = false
+
+	ApplicationId string
 }
 
 // NewClientPolicy generates a new ClientPolicy with default values.

--- a/client_test.go
+++ b/client_test.go
@@ -35,12 +35,20 @@ import (
 
 func isJsonObject(ifc interface{}) bool {
 	switch ifc := ifc.(type) {
-	case float64, float32, int, int64, uint64:
+	case float64, float32, int, int64, uint64, string:
 		return true
 	case []interface{}:
 		for _, v := range ifc {
 			switch v.(type) {
-			case float64, float32, int, int64, uint64:
+			case float64, float32, int, int64, uint64, string:
+				return true
+			case map[string]interface{}:
+				for _, v := range ifc {
+					if !isJsonObject(v) {
+						return false
+					}
+				}
+				return true
 			default:
 				return false
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -461,6 +461,8 @@ var _ = gg.Describe("Aerospike", func() {
 		var wpolicy = as.NewWritePolicy(0, 0)
 		var rpolicy = as.NewPolicy()
 		var bpolicy = as.NewBatchPolicy()
+		bpolicy.TotalTimeout = 1 * time.Minute
+		bpolicy.SocketTimeout = 30 * time.Second
 		var rec *as.Record
 
 		if *useReplicas {
@@ -1268,24 +1270,24 @@ var _ = gg.Describe("Aerospike", func() {
 
 						for i := 0; i < keyCount; i++ {
 							key, err := as.NewKey(ns, set, randString(50))
-							gm.Expect(err).ToNot(gm.HaveOccurred())
+							gm.Expect(err == nil).To(gm.BeTrue())
 							keys = append(keys, key)
 
 							// if key shouldExist == true, put it in the DB
 							if i%2 == 0 {
 								err = client.PutBins(wpolicy, key, bin)
-								gm.Expect(err).ToNot(gm.HaveOccurred())
+								gm.Expect(err == nil).To(gm.BeTrue())
 
 								// make sure they exists in the DB
 								exists, err := client.Exists(rpolicy, key)
-								gm.Expect(err).ToNot(gm.HaveOccurred())
+								gm.Expect(err == nil).To(gm.BeTrue())
 								gm.Expect(exists).To(gm.Equal(true))
 							}
 						}
 
 						bpolicy.AllowInline = useInline
 						exists, err = client.BatchExists(bpolicy, keys)
-						gm.Expect(err).ToNot(gm.HaveOccurred())
+						gm.Expect(err == nil).To(gm.BeTrue())
 						gm.Expect(len(exists)).To(gm.Equal(len(keys)))
 						for idx, keyExists := range exists {
 							gm.Expect(keyExists).To(gm.Equal(idx%2 == 0))

--- a/cluster.go
+++ b/cluster.go
@@ -485,6 +485,7 @@ func (clstr *Cluster) waitTillStabilized() Error {
 	}
 }
 
+// TODO: Not used anywhere. Consider removing
 func (clstr *Cluster) findAlias(alias *Host) *Node {
 	return clstr.aliases.Get(*alias)
 }
@@ -597,6 +598,7 @@ func (clstr *Cluster) findNodeName(list []*Node, name string) bool {
 	return false
 }
 
+// TODO: Not used anywhere. Consider removing
 func (clstr *Cluster) addAlias(host *Host, node *Node) {
 	if host != nil && node != nil {
 		clstr.aliases.Set(*host, node)
@@ -885,10 +887,10 @@ func (clstr *Cluster) MigrationInProgress(timeout time.Duration) (res bool, err 
 		done <- false
 	}()
 
-	dealine := time.After(timeout)
+	deadLine := time.After(timeout)
 	for {
 		select {
-		case <-dealine:
+		case <-deadLine:
 			return false, ErrTimeout.err()
 		case <-done:
 			return res, err
@@ -896,9 +898,9 @@ func (clstr *Cluster) MigrationInProgress(timeout time.Duration) (res bool, err 
 	}
 }
 
-// WaitUntillMigrationIsFinished will block until all
+// WaitUntilMigrationIsFinished will block until all
 // migration operations in the cluster all finished.
-func (clstr *Cluster) WaitUntillMigrationIsFinished(timeout time.Duration) Error {
+func (clstr *Cluster) WaitUntilMigrationIsFinished(timeout time.Duration) Error {
 	if timeout <= 0 {
 		timeout = _NO_TIMEOUT
 	}
@@ -915,9 +917,9 @@ func (clstr *Cluster) WaitUntillMigrationIsFinished(timeout time.Duration) Error
 		}
 	}()
 
-	dealine := time.After(timeout)
+	deadLine := time.After(timeout)
 	select {
-	case <-dealine:
+	case <-deadLine:
 		return ErrTimeout.err()
 	case err := <-done:
 		return err
@@ -986,6 +988,9 @@ func (clstr *Cluster) MetricsEnabled() bool {
 // If the parameters for the histogram in the policy are the different from the one already
 // on the cluster, the metrics will be reset.
 func (clstr *Cluster) EnableMetrics(policy *MetricsPolicy) {
+	if policy == nil {
+		policy = DefaultMetricsPolicy()
+	}
 
 	clstr.metricsPolicy.Set(policy)
 	clstr.metricsEnabled.Store(true)
@@ -1015,6 +1020,12 @@ func (clstr *Cluster) getNodeLabels(metricPolicy *MetricsPolicy) *Labels {
 	// Add node labels
 	for node := range nodes {
 		entries := make(map[string]string)
+		var app_id string
+		if clstr.clientPolicy.ApplicationId != "" {
+			app_id = clstr.clientPolicy.ApplicationId
+		} else {
+			app_id = clstr.user
+		}
 
 		// Merging user labels with node labels
 		if userLabels != nil && userLabels.Labels != nil {
@@ -1032,13 +1043,7 @@ func (clstr *Cluster) getNodeLabels(metricPolicy *MetricsPolicy) *Labels {
 
 		// Users are allowed to override app-id if they want to. Default is the user name.
 		// Users need to set the application id int the client policy.
-		entries["app-id"] = func() string {
-			if clstr.clientPolicy.ApplicationId != "" {
-				return clstr.clientPolicy.ApplicationId
-			} else {
-				return clstr.user
-			}
-		}()
+		entries["app-id"] = app_id
 
 		labels = append(labels, entries)
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -379,9 +379,11 @@ func (clstr *Cluster) aggregateNodeStats(nodeList []*Node) {
 	for _, node := range nodeList {
 		h := node.host.String()
 		if stats, exists := clstr.stats[h]; exists {
-			stats.aggregate(node.stats.getAndReset())
+			nr := node.stats.getAndReset()
+			stats.aggregate(nr)
 		} else {
-			clstr.stats[h] = node.stats.getAndReset()
+			nr := node.stats.getAndReset()
+			clstr.stats[h] = nr
 		}
 	}
 }
@@ -984,9 +986,6 @@ func (clstr *Cluster) MetricsEnabled() bool {
 // If the parameters for the histogram in the policy are the different from the one already
 // on the cluster, the metrics will be reset.
 func (clstr *Cluster) EnableMetrics(policy *MetricsPolicy) {
-	if policy == nil {
-		policy = DefaultMetricsPolicy()
-	}
 
 	clstr.metricsPolicy.Set(policy)
 	clstr.metricsEnabled.Store(true)
@@ -1002,6 +1001,49 @@ func (clstr *Cluster) EnableMetrics(policy *MetricsPolicy) {
 	for _, node := range clstr.GetNodes() {
 		node.stats.reshape(policy)
 	}
+}
+
+func (clstr *Cluster) getNodeLabels(metricPolicy *MetricsPolicy) *Labels {
+	var userLabels *Labels
+	if metricPolicy == nil && clstr.metricsPolicy.Get() != nil && clstr.metricsPolicy.Get().Labels != nil {
+		userLabels = clstr.metricsPolicy.Get().Labels
+	}
+
+	nodes := clstr.GetNodes()
+	labels := make([]map[string]string, 0)
+
+	// Add node labels
+	for node := range nodes {
+		entries := make(map[string]string)
+
+		// Merging user labels with node labels
+		if userLabels != nil && userLabels.Labels != nil {
+			for _, userLabel := range *userLabels.Labels {
+				for k, v := range userLabel {
+					entries[k] = v
+				}
+			}
+		}
+
+		// Reserved label names for the client
+		entries["node"] = nodes[node].GetName()
+		entries["host"] = nodes[node].host.String()
+		entries["cluster"] = clstr.clientPolicy.ClusterName
+
+		// Users are allowed to override app-id if they want to. Default is the user name.
+		// Users need to set the application id int the client policy.
+		entries["app-id"] = func() string {
+			if clstr.clientPolicy.ApplicationId != "" {
+				return clstr.clientPolicy.ApplicationId
+			} else {
+				return clstr.user
+			}
+		}()
+
+		labels = append(labels, entries)
+	}
+
+	return NewLabels(labels...)
 }
 
 // DisableMetrics disables the cluster command metrics gathering.

--- a/command.go
+++ b/command.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	amap "github.com/aerospike/aerospike-client-go/v8/internal/atomic/map"
+
 	"github.com/aerospike/aerospike-client-go/v8/logger"
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/aerospike/aerospike-client-go/v8/types/pool"
@@ -151,6 +153,38 @@ var (
 	buffPool = pool.NewTieredBufferPool(MinBufferSize, PoolCutOffBufferSize)
 )
 
+// Return string representation of command type.
+func (ct commandType) String() string {
+	switch ct {
+	case ttNone:
+		return "None"
+	case ttGet:
+		return "Get"
+	case ttGetHeader:
+		return "GetHeader"
+	case ttExists:
+		return "Exists"
+	case ttPut:
+		return "Put"
+	case ttDelete:
+		return "Delete"
+	case ttOperate:
+		return "Operate"
+	case ttQuery:
+		return "Query"
+	case ttScan:
+		return "Scan"
+	case ttUDF:
+		return "UDF"
+	case ttBatchRead:
+		return "BatchRead"
+	case ttBatchWrite:
+		return "BatchWrite"
+	default:
+		return fmt.Sprintf("commandType(%d)", int(ct))
+	}
+}
+
 // command interface describes all commands available
 type command interface {
 	getPolicy(ifc command) Policy
@@ -173,6 +207,8 @@ type command interface {
 	executeAt(ifc command, policy *BasePolicy, deadline time.Time, iterations int) Error
 
 	canPutConnBack() bool
+
+	getNamespace() *map[string]uint64
 
 	// Executes the command
 	Execute() Error
@@ -3605,7 +3641,6 @@ func (cmd *baseCommand) executeIter(ifc command, iter int) Error {
 func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time.Time, iterations int) (errChain Error) {
 	// for exponential backoff
 	interval := policy.SleepBetweenRetries
-
 	transStart := time.Now()
 
 	notFirstIteration := false
@@ -3613,7 +3648,6 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 	loopCount := 0
 
 	var err Error
-
 	// Execute command until successful, timed out or maximum iterations have been reached.
 	for {
 		cmd.commandSentCounter++
@@ -3675,7 +3709,6 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 		if policy.TotalTimeout > 0 && time.Now().After(deadline) {
 			break
 		}
-
 		// set command node, so when you return a record it has the node
 		cmd.node, err = ifc.getNode(ifc)
 		if cmd.node == nil || !cmd.node.IsActive() || err != nil {
@@ -3690,6 +3723,8 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 			continue
 		}
 
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+
 		// check if node has encountered too many errors
 		if err = cmd.node.validateErrorCount(); err != nil {
 			isClientTimeout = false
@@ -3703,7 +3738,15 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 			continue
 		}
 
-		cmd.conn, err = ifc.getConnection(policy)
+		if metricsEnabled {
+			start := time.Now()
+			cmd.conn, err = ifc.getConnection(policy)
+			// Capture connection acquire time.
+			cmd.applyDetailedMetricsConnectionAq(ifc, start)
+		} else {
+			cmd.conn, err = ifc.getConnection(policy)
+		}
+
 		if err != nil {
 			isClientTimeout = false
 
@@ -3734,6 +3777,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 
 		// Set command buffer.
 		err = ifc.writeBuffer(ifc)
+
 		if err != nil {
 			applyTransactionErrorMetrics(cmd.node)
 
@@ -3768,7 +3812,17 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 
 		// Send command.
 		cmd.commandWasSent = true
-		_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
+		var dataReceived int
+		if metricsEnabled {
+			start := time.Now()
+			dataSent := len(cmd.dataBuffer[:cmd.dataOffset])
+			dataReceived, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
+			// Capture sent bytes and transmission time.
+			cmd.applyDetailedMetricsDataSizeAndLatency(ifc, dataSent, dataReceived, start)
+		} else {
+			_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
+		}
+
 		if err != nil {
 			applyTransactionErrorMetrics(cmd.node)
 
@@ -3790,7 +3844,15 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 		}
 
 		// Parse results.
-		err = ifc.parseResult(ifc, cmd.conn)
+		if metricsEnabled {
+			start := time.Now()
+			err = ifc.parseResult(ifc, cmd.conn)
+			// Capture timing for parsing results.
+			cmd.applyDetailedMetricsParsing(ifc, start)
+		} else {
+			err = ifc.parseResult(ifc, cmd.conn)
+		}
+
 		if err != nil {
 			applyTransactionErrorMetrics(cmd.node)
 
@@ -3947,6 +4009,7 @@ func applyMetrics(tt commandType, metrics *nodeStats, s time.Time) {
 	}
 }
 
+// TODO: This is not used anywhere. Remove?
 func (cmd *baseCommand) parseVersion(fieldCount int) *uint64 {
 	var version *uint64
 
@@ -3964,4 +4027,73 @@ func (cmd *baseCommand) parseVersion(fieldCount int) *uint64 {
 		cmd.dataOffset += int(size)
 	}
 	return version
+}
+
+// applyDetailedMetricsParsing updates the detailed metrics for parsing time.
+func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.Time) {
+	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
+		end := uint64(time.Since(startTime).Microseconds())
+		for namespace := range *ifc.getNamespace() {
+			if namespace != "" {
+				cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+					a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
+						b.Parsing.Add(end)
+						return b
+					}, func() *commandMetric {
+						return cmd.node.stats.newCommandMetric()
+					})
+					return a
+				}, func() *amap.Map[commandType, *commandMetric] {
+					return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
+				})
+			}
+		}
+	}
+}
+
+// applyDetailedMetricsConnectionAq updates the detailed metrics for connection acquire time.
+func (cmd *baseCommand) applyDetailedMetricsConnectionAq(ifc command, startTime time.Time) {
+	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
+		end := uint64(time.Since(startTime).Microseconds())
+		for namespace := range *ifc.getNamespace() {
+			if namespace != "" {
+				cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+					a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
+						b.ConnectionAq.Add(end)
+						return b
+					}, func() *commandMetric {
+						return cmd.node.stats.newCommandMetric()
+					})
+					return a
+				}, func() *amap.Map[commandType, *commandMetric] {
+					return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
+				})
+			}
+		}
+	}
+}
+
+// applyDetailedMetricsDataSizeAndLatency updates the detailed metrics for bytes sent and transmission time.
+func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatency(ifc command, bytesSent int, bytesReceived int, startTime time.Time) {
+	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
+		end := uint64(time.Since(startTime).Microseconds())
+		for namespace := range *ifc.getNamespace() {
+			if namespace != "" {
+				cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+					a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
+						b.BytesReceived.Add(uint64(bytesReceived))
+						b.BytesSent.Add(uint64(bytesSent))
+						b.Latency.Add(end)
+						return b
+					}, func() *commandMetric {
+						return cmd.node.stats.newCommandMetric()
+					})
+					return a
+				}, func() *amap.Map[commandType, *commandMetric] {
+					return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
+				})
+			}
+		}
+
+	}
 }

--- a/command.go
+++ b/command.go
@@ -208,7 +208,7 @@ type command interface {
 
 	canPutConnBack() bool
 
-	getNamespaces() *map[string]uint64
+	getNamespaces() map[string]uint64
 	getNamespace() *string
 
 	// Executes the command
@@ -3815,8 +3815,8 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 		cmd.commandWasSent = true
 		if metricsEnabled {
 			start := time.Now()
-			dataSent := len(cmd.dataBuffer[:cmd.dataOffset])
-			_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
+			var dataSent int
+			dataSent, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
 			// Capture sent bytes and transmission time.
 			cmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(ifc, dataSent, start)
 		} else {
@@ -3847,8 +3847,10 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 		if metricsEnabled {
 			start := time.Now()
 			err = ifc.parseResult(ifc, cmd.conn)
-			// Capture timing for parsing results.
-			cmd.applyDetailedMetricsParsing(ifc, start)
+			dataReceived := cmd.conn.totalReceived
+			logger.Logger.Debug("Node " + cmd.node.String() + ": " + fmt.Sprintf("Received %d bytes", dataReceived) + ", command type: " + ifc.commandType().String())
+			// Capture timing for parsing results and total bytes received from the server.
+			cmd.applyDetailedMetricsParsing(ifc, start, dataReceived)
 		} else {
 			err = ifc.parseResult(ifc, cmd.conn)
 		}
@@ -4030,7 +4032,7 @@ func (cmd *baseCommand) parseVersion(fieldCount int) *uint64 {
 }
 
 // applyDetailedMetricsParsing updates the detailed metrics for parsing time.
-func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.Time) {
+func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.Time, dataReceived int64) {
 	if cmd.node == nil || cmd.node.cluster == nil || !cmd.node.cluster.MetricsEnabled() {
 		return
 	}
@@ -4039,24 +4041,7 @@ func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.
 	ct := ifc.commandType()
 	dm := &cmd.node.stats.DetailedMetrics
 
-	if nsMap := ifc.getNamespaces(); nsMap != nil {
-		for ns := range *nsMap {
-			if ns == "" {
-				continue
-			}
-			inner := dm.Get(ns)
-			if inner == nil {
-				inner = amap.New[commandType, *commandMetric](0)
-				dm.Set(ns, inner)
-			}
-			cm := inner.Get(ct)
-			if cm == nil {
-				cm = cmd.node.stats.newCommandMetric()
-				inner.Set(ct, cm)
-			}
-			cm.Parsing.Add(end)
-		}
-	} else if single := ifc.getNamespace(); *single != "" {
+	if single := ifc.getNamespace(); single != nil {
 		ns := *single
 
 		inner := dm.Get(ns)
@@ -4072,6 +4057,25 @@ func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.
 		}
 
 		cm.Parsing.Add(end)
+		cm.BytesReceived.Add(uint64(dataReceived))
+	} else if nsMap := ifc.getNamespaces(); nsMap != nil {
+		for ns := range nsMap {
+			if ns == "" {
+				continue
+			}
+			inner := dm.Get(ns)
+			if inner == nil {
+				inner = amap.New[commandType, *commandMetric](0)
+				dm.Set(ns, inner)
+			}
+			cm := inner.Get(ct)
+			if cm == nil {
+				cm = cmd.node.stats.newCommandMetric()
+				inner.Set(ct, cm)
+			}
+			cm.Parsing.Add(end)
+			cm.BytesReceived.Add(uint64(dataReceived))
+		}
 	}
 }
 
@@ -4081,8 +4085,22 @@ func (cmd *baseCommand) applyDetailedMetricsConnectionAq(ifc command, startTime 
 	ct := ifc.commandType()
 	dm := &cmd.node.stats.DetailedMetrics
 
-	if nsMap := ifc.getNamespaces(); nsMap != nil {
-		for ns := range *nsMap {
+	if single := ifc.getNamespace(); single != nil {
+		inner := dm.Get(*single)
+		if inner == nil {
+			inner = amap.New[commandType, *commandMetric](0)
+			dm.Set(*single, inner)
+		}
+
+		cm := inner.Get(ct)
+		if cm == nil {
+			cm = cmd.node.stats.newCommandMetric()
+			inner.Set(ct, cm)
+		}
+
+		cm.ConnectionAq.Add(end)
+	} else if nsMap := ifc.getNamespaces(); nsMap != nil {
+		for ns := range nsMap {
 			if ns == "" {
 				continue
 			}
@@ -4100,20 +4118,6 @@ func (cmd *baseCommand) applyDetailedMetricsConnectionAq(ifc command, startTime 
 
 			cm.ConnectionAq.Add(end)
 		}
-	} else if single := ifc.getNamespace(); *single != "" {
-		inner := dm.Get(*single)
-		if inner == nil {
-			inner = amap.New[commandType, *commandMetric](0)
-			dm.Set(*single, inner)
-		}
-
-		cm := inner.Get(ct)
-		if cm == nil {
-			cm = cmd.node.stats.newCommandMetric()
-			inner.Set(ct, cm)
-		}
-
-		cm.ConnectionAq.Add(end)
 	}
 }
 
@@ -4122,9 +4126,23 @@ func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatencyOnWrite(ifc comman
 	end := uint64(time.Since(startTime).Microseconds())
 	ct := ifc.commandType()
 	dm := &cmd.node.stats.DetailedMetrics
-
-	if nsMap := ifc.getNamespaces(); nsMap != nil {
-		for ns := range *nsMap {
+	if singleNS := ifc.getNamespace(); singleNS != nil {
+		if *singleNS != "" {
+			inner := dm.Get(*singleNS)
+			if inner == nil {
+				inner = amap.New[commandType, *commandMetric](1)
+				dm.Set(*singleNS, inner)
+			}
+			cm := inner.Get(ct)
+			if cm == nil {
+				cm = cmd.node.stats.newCommandMetric()
+				inner.Set(ct, cm)
+			}
+			cm.BytesSent.Add(uint64(bytesSent))
+			cm.Latency.Add(end)
+		}
+	} else if nsMap := ifc.getNamespaces(); nsMap != nil {
+		for ns := range nsMap {
 			if ns != "" {
 				//upsert(ns)
 				inner := dm.Get(ns)
@@ -4140,21 +4158,6 @@ func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatencyOnWrite(ifc comman
 				cm.BytesSent.Add(uint64(bytesSent))
 				cm.Latency.Add(end)
 			}
-		}
-	} else if singleNS := ifc.getNamespace(); *singleNS != "" {
-		if *singleNS != "" {
-			inner := dm.Get(*singleNS)
-			if inner == nil {
-				inner = amap.New[commandType, *commandMetric](1)
-				dm.Set(*singleNS, inner)
-			}
-			cm := inner.Get(ct)
-			if cm == nil {
-				cm = cmd.node.stats.newCommandMetric()
-				inner.Set(ct, cm)
-			}
-			cm.BytesSent.Add(uint64(bytesSent))
-			cm.Latency.Add(end)
 		}
 	}
 }

--- a/command.go
+++ b/command.go
@@ -3818,7 +3818,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 			dataSent := len(cmd.dataBuffer[:cmd.dataOffset])
 			_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
 			// Capture sent bytes and transmission time.
-			cmd.applyDetailedMetricsDataSizeAndLatency(ifc, dataSent, start)
+			cmd.applyDetailedMetricsDataSizeAndLatencyOnWrite(ifc, dataSent, start)
 		} else {
 			_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
 		}
@@ -4117,8 +4117,8 @@ func (cmd *baseCommand) applyDetailedMetricsConnectionAq(ifc command, startTime 
 	}
 }
 
-// applyDetailedMetricsDataSizeAndLatency updates the detailed metrics for bytes sent and transmission time.
-func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatency(ifc command, bytesSent int, startTime time.Time) {
+// applyDetailedMetricsDataSizeAndLatencyOnWrite updates the detailed metrics for bytes sent and transmission time.
+func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatencyOnWrite(ifc command, bytesSent int, startTime time.Time) {
 	end := uint64(time.Since(startTime).Microseconds())
 	ct := ifc.commandType()
 	dm := &cmd.node.stats.DetailedMetrics

--- a/command.go
+++ b/command.go
@@ -208,7 +208,8 @@ type command interface {
 
 	canPutConnBack() bool
 
-	getNamespace() *map[string]uint64
+	getNamespaces() *map[string]uint64
+	getNamespace() *string
 
 	// Executes the command
 	Execute() Error
@@ -3812,13 +3813,12 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 
 		// Send command.
 		cmd.commandWasSent = true
-		var dataReceived int
 		if metricsEnabled {
 			start := time.Now()
 			dataSent := len(cmd.dataBuffer[:cmd.dataOffset])
-			dataReceived, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
+			_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
 			// Capture sent bytes and transmission time.
-			cmd.applyDetailedMetricsDataSizeAndLatency(ifc, dataSent, dataReceived, start)
+			cmd.applyDetailedMetricsDataSizeAndLatency(ifc, dataSent, start)
 		} else {
 			_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
 		}
@@ -4033,67 +4033,102 @@ func (cmd *baseCommand) parseVersion(fieldCount int) *uint64 {
 func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.Time) {
 	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
 		end := uint64(time.Since(startTime).Microseconds())
-		for namespace := range *ifc.getNamespace() {
-			if namespace != "" {
-				cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-					a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
-						b.Parsing.Add(end)
-						return b
-					}, func() *commandMetric {
-						return cmd.node.stats.newCommandMetric()
-					})
-					return a
-				}, func() *amap.Map[commandType, *commandMetric] {
-					return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
-				})
+		namespaces := ifc.getNamespaces()
+		if namespaces != nil {
+			for namespace := range *namespaces {
+				if namespace != "" {
+					applyParsingHelper(cmd, ifc, namespace, end)
+				}
+			}
+		} else {
+			namespace := ifc.getNamespace()
+			if *namespace != "" {
+				applyParsingHelper(cmd, ifc, *namespace, end)
 			}
 		}
 	}
+}
+
+func applyParsingHelper(cmd *baseCommand, ifc command, namespace string, end uint64) {
+	cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+		a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
+			b.Parsing.Add(end)
+			return b
+		}, func() *commandMetric {
+			return cmd.node.stats.newCommandMetric()
+		})
+		return a
+	}, func() *amap.Map[commandType, *commandMetric] {
+		return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
+	})
 }
 
 // applyDetailedMetricsConnectionAq updates the detailed metrics for connection acquire time.
 func (cmd *baseCommand) applyDetailedMetricsConnectionAq(ifc command, startTime time.Time) {
 	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
 		end := uint64(time.Since(startTime).Microseconds())
-		for namespace := range *ifc.getNamespace() {
+		namespaces := ifc.getNamespaces()
+		if namespaces != nil {
+			for namespace := range *namespaces {
+				if namespace != "" {
+					applyConnectionAqHelper(cmd, ifc, namespace, end)
+				}
+			}
+		} else {
+			namespace := *ifc.getNamespace()
 			if namespace != "" {
-				cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-					a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
-						b.ConnectionAq.Add(end)
-						return b
-					}, func() *commandMetric {
-						return cmd.node.stats.newCommandMetric()
-					})
-					return a
-				}, func() *amap.Map[commandType, *commandMetric] {
-					return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
-				})
+				applyConnectionAqHelper(cmd, ifc, namespace, end)
 			}
 		}
 	}
 }
 
+func applyConnectionAqHelper(cmd *baseCommand, ifc command, namespace string, end uint64) {
+	cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+		a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
+			b.ConnectionAq.Add(end)
+			return b
+		}, func() *commandMetric {
+			return cmd.node.stats.newCommandMetric()
+		})
+		return a
+	}, func() *amap.Map[commandType, *commandMetric] {
+		return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
+	})
+}
+
 // applyDetailedMetricsDataSizeAndLatency updates the detailed metrics for bytes sent and transmission time.
-func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatency(ifc command, bytesSent int, bytesReceived int, startTime time.Time) {
+func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatency(ifc command, bytesSent int, startTime time.Time) {
 	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
 		end := uint64(time.Since(startTime).Microseconds())
-		for namespace := range *ifc.getNamespace() {
-			if namespace != "" {
-				cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-					a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
-						b.BytesReceived.Add(uint64(bytesReceived))
-						b.BytesSent.Add(uint64(bytesSent))
-						b.Latency.Add(end)
-						return b
-					}, func() *commandMetric {
-						return cmd.node.stats.newCommandMetric()
-					})
-					return a
-				}, func() *amap.Map[commandType, *commandMetric] {
-					return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
-				})
+		namespaces := ifc.getNamespaces()
+		if namespaces != nil {
+			for namespace := range *namespaces {
+				if namespace != "" {
+					applyDetailedMetricsDataSizeAndLatencyHelper(cmd, ifc, namespace, end, bytesSent)
+				}
+			}
+		} else {
+			namespace := ifc.getNamespace()
+			if *namespace != "" {
+				applyDetailedMetricsDataSizeAndLatencyHelper(cmd, ifc, *namespace, end, bytesSent)
 			}
 		}
-
 	}
+}
+
+func applyDetailedMetricsDataSizeAndLatencyHelper(cmd *baseCommand, ifc command, namespace string, end uint64, bytesSent int) {
+	// Update the detailed metrics for bytes sent and transmission time.
+	cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+		a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
+			b.BytesSent.Add(uint64(bytesSent))
+			b.Latency.Add(end)
+			return b
+		}, func() *commandMetric {
+			return cmd.node.stats.newCommandMetric()
+		})
+		return a
+	}, func() *amap.Map[commandType, *commandMetric] {
+		return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
+	})
 }

--- a/command.go
+++ b/command.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"iter"
 	"time"
 
 	amap "github.com/aerospike/aerospike-client-go/v8/internal/atomic/map"
@@ -208,7 +209,7 @@ type command interface {
 
 	canPutConnBack() bool
 
-	getNamespaces() map[string]uint64
+	getNamespaces() iter.Seq2[string, uint64]
 	getNamespace() *string
 
 	// Executes the command
@@ -4141,8 +4142,8 @@ func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatencyOnWrite(ifc comman
 			cm.BytesSent.Add(uint64(bytesSent))
 			cm.Latency.Add(end)
 		}
-	} else if nsMap := ifc.getNamespaces(); nsMap != nil {
-		for ns := range nsMap {
+	} else if nsIter := ifc.getNamespaces(); nsIter != nil { // allocation happens
+		for ns := range nsIter {
 			if ns != "" {
 				//upsert(ns)
 				inner := dm.Get(ns)

--- a/command.go
+++ b/command.go
@@ -4031,104 +4031,130 @@ func (cmd *baseCommand) parseVersion(fieldCount int) *uint64 {
 
 // applyDetailedMetricsParsing updates the detailed metrics for parsing time.
 func (cmd *baseCommand) applyDetailedMetricsParsing(ifc command, startTime time.Time) {
-	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
-		end := uint64(time.Since(startTime).Microseconds())
-		namespaces := ifc.getNamespaces()
-		if namespaces != nil {
-			for namespace := range *namespaces {
-				if namespace != "" {
-					applyParsingHelper(cmd, ifc, namespace, end)
-				}
-			}
-		} else {
-			namespace := ifc.getNamespace()
-			if *namespace != "" {
-				applyParsingHelper(cmd, ifc, *namespace, end)
-			}
-		}
+	if cmd.node == nil || cmd.node.cluster == nil || !cmd.node.cluster.MetricsEnabled() {
+		return
 	}
-}
 
-func applyParsingHelper(cmd *baseCommand, ifc command, namespace string, end uint64) {
-	cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-		a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
-			b.Parsing.Add(end)
-			return b
-		}, func() *commandMetric {
-			return cmd.node.stats.newCommandMetric()
-		})
-		return a
-	}, func() *amap.Map[commandType, *commandMetric] {
-		return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
-	})
+	end := uint64(time.Since(startTime).Microseconds())
+	ct := ifc.commandType()
+	dm := &cmd.node.stats.DetailedMetrics
+
+	if nsMap := ifc.getNamespaces(); nsMap != nil {
+		for ns := range *nsMap {
+			if ns == "" {
+				continue
+			}
+			inner := dm.Get(ns)
+			if inner == nil {
+				inner = amap.New[commandType, *commandMetric](0)
+				dm.Set(ns, inner)
+			}
+			cm := inner.Get(ct)
+			if cm == nil {
+				cm = cmd.node.stats.newCommandMetric()
+				inner.Set(ct, cm)
+			}
+			cm.Parsing.Add(end)
+		}
+	} else if single := ifc.getNamespace(); *single != "" {
+		ns := *single
+
+		inner := dm.Get(ns)
+		if inner == nil {
+			inner = amap.New[commandType, *commandMetric](0)
+			dm.Set(ns, inner)
+		}
+
+		cm := inner.Get(ct)
+		if cm == nil {
+			cm = cmd.node.stats.newCommandMetric()
+			inner.Set(ct, cm)
+		}
+
+		cm.Parsing.Add(end)
+	}
 }
 
 // applyDetailedMetricsConnectionAq updates the detailed metrics for connection acquire time.
 func (cmd *baseCommand) applyDetailedMetricsConnectionAq(ifc command, startTime time.Time) {
-	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
-		end := uint64(time.Since(startTime).Microseconds())
-		namespaces := ifc.getNamespaces()
-		if namespaces != nil {
-			for namespace := range *namespaces {
-				if namespace != "" {
-					applyConnectionAqHelper(cmd, ifc, namespace, end)
-				}
-			}
-		} else {
-			namespace := *ifc.getNamespace()
-			if namespace != "" {
-				applyConnectionAqHelper(cmd, ifc, namespace, end)
-			}
-		}
-	}
-}
+	end := uint64(time.Since(startTime).Microseconds())
+	ct := ifc.commandType()
+	dm := &cmd.node.stats.DetailedMetrics
 
-func applyConnectionAqHelper(cmd *baseCommand, ifc command, namespace string, end uint64) {
-	cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-		a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
-			b.ConnectionAq.Add(end)
-			return b
-		}, func() *commandMetric {
-			return cmd.node.stats.newCommandMetric()
-		})
-		return a
-	}, func() *amap.Map[commandType, *commandMetric] {
-		return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
-	})
+	if nsMap := ifc.getNamespaces(); nsMap != nil {
+		for ns := range *nsMap {
+			if ns == "" {
+				continue
+			}
+			inner := dm.Get(ns)
+			if inner == nil {
+				inner = amap.New[commandType, *commandMetric](0)
+				dm.Set(ns, inner)
+			}
+
+			cm := inner.Get(ct)
+			if cm == nil {
+				cm = cmd.node.stats.newCommandMetric()
+				inner.Set(ct, cm)
+			}
+
+			cm.ConnectionAq.Add(end)
+		}
+	} else if single := ifc.getNamespace(); *single != "" {
+		inner := dm.Get(*single)
+		if inner == nil {
+			inner = amap.New[commandType, *commandMetric](0)
+			dm.Set(*single, inner)
+		}
+
+		cm := inner.Get(ct)
+		if cm == nil {
+			cm = cmd.node.stats.newCommandMetric()
+			inner.Set(ct, cm)
+		}
+
+		cm.ConnectionAq.Add(end)
+	}
 }
 
 // applyDetailedMetricsDataSizeAndLatency updates the detailed metrics for bytes sent and transmission time.
 func (cmd *baseCommand) applyDetailedMetricsDataSizeAndLatency(ifc command, bytesSent int, startTime time.Time) {
-	if cmd.node != nil && cmd.node.cluster != nil && cmd.node.cluster.MetricsEnabled() {
-		end := uint64(time.Since(startTime).Microseconds())
-		namespaces := ifc.getNamespaces()
-		if namespaces != nil {
-			for namespace := range *namespaces {
-				if namespace != "" {
-					applyDetailedMetricsDataSizeAndLatencyHelper(cmd, ifc, namespace, end, bytesSent)
+	end := uint64(time.Since(startTime).Microseconds())
+	ct := ifc.commandType()
+	dm := &cmd.node.stats.DetailedMetrics
+
+	if nsMap := ifc.getNamespaces(); nsMap != nil {
+		for ns := range *nsMap {
+			if ns != "" {
+				//upsert(ns)
+				inner := dm.Get(ns)
+				if inner == nil {
+					inner = amap.New[commandType, *commandMetric](1)
+					dm.Set(ns, inner)
 				}
-			}
-		} else {
-			namespace := ifc.getNamespace()
-			if *namespace != "" {
-				applyDetailedMetricsDataSizeAndLatencyHelper(cmd, ifc, *namespace, end, bytesSent)
+				cm := inner.Get(ct)
+				if cm == nil {
+					cm = cmd.node.stats.newCommandMetric()
+					inner.Set(ct, cm)
+				}
+				cm.BytesSent.Add(uint64(bytesSent))
+				cm.Latency.Add(end)
 			}
 		}
+	} else if singleNS := ifc.getNamespace(); *singleNS != "" {
+		if *singleNS != "" {
+			inner := dm.Get(*singleNS)
+			if inner == nil {
+				inner = amap.New[commandType, *commandMetric](1)
+				dm.Set(*singleNS, inner)
+			}
+			cm := inner.Get(ct)
+			if cm == nil {
+				cm = cmd.node.stats.newCommandMetric()
+				inner.Set(ct, cm)
+			}
+			cm.BytesSent.Add(uint64(bytesSent))
+			cm.Latency.Add(end)
+		}
 	}
-}
-
-func applyDetailedMetricsDataSizeAndLatencyHelper(cmd *baseCommand, ifc command, namespace string, end uint64, bytesSent int) {
-	// Update the detailed metrics for bytes sent and transmission time.
-	cmd.node.stats.DetailedMetrics.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-		a.UpdateOrInsertFn(ifc.commandType(), func(b *commandMetric) *commandMetric {
-			b.BytesSent.Add(uint64(bytesSent))
-			b.Latency.Add(end)
-			return b
-		}, func() *commandMetric {
-			return cmd.node.stats.newCommandMetric()
-		})
-		return a
-	}, func() *amap.Map[commandType, *commandMetric] {
-		return amap.NewWithValue(ifc.commandType(), cmd.node.stats.newCommandMetric())
-	})
 }

--- a/connection.go
+++ b/connection.go
@@ -72,7 +72,8 @@ type Connection struct {
 	idleDeadline time.Time
 
 	// connection object
-	conn net.Conn
+	conn          net.Conn
+	totalReceived int64
 
 	// histogram to adjust the buff size to optimal value over time
 	buffHist             *histogram.Log2
@@ -254,8 +255,10 @@ func (ctn *Connection) Read(buf []byte, length int) (total int, aerr Error) {
 
 		if !ctn.compressed {
 			r, err = ctn.conn.Read(buf[total:length])
+			ctn.totalReceived += int64(r)
 		} else {
 			r, err = ctn.inflater.Read(buf[total:length])
+			ctn.totalReceived += int64(length - total)
 			if err == io.EOF && total+r == length {
 				ctn.compressed = false
 				err = ctn.inflater.Close()
@@ -482,6 +485,7 @@ func (ctn *Connection) willBeIdleIn(tendInterval time.Duration) bool {
 
 // refresh extends the idle deadline of the connection.
 func (ctn *Connection) refresh() {
+	ctn.totalReceived = 0
 	now := time.Now()
 	ctn.idleDeadline = now.Add(ctn.idleTimeout)
 	if ctn.inflater != nil {

--- a/delete_command.go
+++ b/delete_command.go
@@ -87,7 +87,7 @@ func (cmd *deleteCommand) commandType() commandType {
 	return ttDelete
 }
 
-func (cmd *deleteCommand) getNamespaces() *map[string]uint64 {
+func (cmd *deleteCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/delete_command.go
+++ b/delete_command.go
@@ -54,6 +54,12 @@ func (cmd *deleteCommand) parseResult(ifc command, conn *Connection) Error {
 		return newCustomNodeError(cmd.node, err.resultCode())
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, resultCode)
+	}
+
 	switch types.ResultCode(resultCode) {
 	case 0:
 		cmd.existed = true
@@ -79,4 +85,11 @@ func (cmd *deleteCommand) Execute() Error {
 
 func (cmd *deleteCommand) commandType() commandType {
 	return ttDelete
+}
+
+func (cmd *deleteCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/delete_command.go
+++ b/delete_command.go
@@ -87,9 +87,10 @@ func (cmd *deleteCommand) commandType() commandType {
 	return ttDelete
 }
 
-func (cmd *deleteCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *deleteCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *deleteCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/delete_command.go
+++ b/delete_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -87,7 +89,7 @@ func (cmd *deleteCommand) commandType() commandType {
 	return ttDelete
 }
 
-func (cmd *deleteCommand) getNamespaces() map[string]uint64 {
+func (cmd *deleteCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/execute_command.go
+++ b/execute_command.go
@@ -118,7 +118,7 @@ func (cmd *executeCommand) GetRecord() *Record {
 	return cmd.record
 }
 
-func (cmd *executeCommand) getNamespaces() *map[string]uint64 {
+func (cmd *executeCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/execute_command.go
+++ b/execute_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/logger"
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
@@ -118,7 +120,7 @@ func (cmd *executeCommand) GetRecord() *Record {
 	return cmd.record
 }
 
-func (cmd *executeCommand) getNamespaces() map[string]uint64 {
+func (cmd *executeCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/execute_command.go
+++ b/execute_command.go
@@ -118,9 +118,10 @@ func (cmd *executeCommand) GetRecord() *Record {
 	return cmd.record
 }
 
-func (cmd *executeCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *executeCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *executeCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/execute_command.go
+++ b/execute_command.go
@@ -64,6 +64,12 @@ func (cmd *executeCommand) parseResult(ifc command, conn *Connection) Error {
 		return err
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	if rp.resultCode != 0 {
 		if rp.resultCode == types.KEY_NOT_FOUND_ERROR {
 			return ErrKeyNotFound.err()
@@ -110,4 +116,11 @@ func (cmd *executeCommand) handleUdfError(resultCode types.ResultCode) Error {
 
 func (cmd *executeCommand) GetRecord() *Record {
 	return cmd.record
+}
+
+func (cmd *executeCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/exists_command.go
+++ b/exists_command.go
@@ -52,6 +52,12 @@ func (cmd *existsCommand) parseResult(ifc command, conn *Connection) Error {
 		return err
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	switch rp.resultCode {
 	case types.OK:
 		cmd.exists = true
@@ -77,4 +83,11 @@ func (cmd *existsCommand) Execute() Error {
 
 func (cmd *existsCommand) commandType() commandType {
 	return ttExists
+}
+
+func (cmd *existsCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/exists_command.go
+++ b/exists_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -85,7 +87,7 @@ func (cmd *existsCommand) commandType() commandType {
 	return ttExists
 }
 
-func (cmd *existsCommand) getNamespaces() map[string]uint64 {
+func (cmd *existsCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/exists_command.go
+++ b/exists_command.go
@@ -85,9 +85,10 @@ func (cmd *existsCommand) commandType() commandType {
 	return ttExists
 }
 
-func (cmd *existsCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *existsCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *existsCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/exists_command.go
+++ b/exists_command.go
@@ -85,7 +85,7 @@ func (cmd *existsCommand) commandType() commandType {
 	return ttExists
 }
 
-func (cmd *existsCommand) getNamespaces() *map[string]uint64 {
+func (cmd *existsCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/internal/atomic/map/map.go
+++ b/internal/atomic/map/map.go
@@ -84,11 +84,9 @@ func (m *Map[K, V]) Length() int {
 func (m *Map[K, V]) Clone() map[K]V {
 	m.mutex.RLock()
 	res := make(map[K]V, len(m.m))
+
 	maps.Copy(m.m, res)
 
-	for k, v := range m.m {
-		res[k] = v
-	}
 	m.mutex.RUnlock()
 
 	return res

--- a/internal/atomic/map/map.go
+++ b/internal/atomic/map/map.go
@@ -15,6 +15,7 @@
 package atomic
 
 import (
+	"maps"
 	"sync"
 )
 
@@ -29,6 +30,14 @@ func New[K comparable, V any](length int) *Map[K, V] {
 	return &Map[K, V]{
 		m: make(map[K]V, length),
 	}
+}
+
+// New generates a new Map instance with initial entry.
+func NewWithValue[K comparable, V any](k K, v V) *Map[K, V] {
+	value := New[K, V](0)
+	value.m[k] = v
+
+	return value
 }
 
 // Exists atomically checks if a key exists in the map
@@ -75,10 +84,45 @@ func (m *Map[K, V]) Length() int {
 func (m *Map[K, V]) Clone() map[K]V {
 	m.mutex.RLock()
 	res := make(map[K]V, len(m.m))
+	maps.Copy(m.m, res)
+
 	for k, v := range m.m {
 		res[k] = v
 	}
 	m.mutex.RUnlock()
+
+	return res
+}
+
+// CloneMap copies the map and returns the copy.
+func (m *Map[K, V]) CloneMap() *Map[K, V] {
+	m.mutex.RLock()
+	res := New[K, V](len(m.m))
+	res.mutex.Lock()
+
+	// Using deep copy
+	maps.Copy(res.m, m.m)
+
+	res.mutex.Unlock()
+	m.mutex.RUnlock()
+
+	return res
+}
+
+// CloneAndResetMap copies the map and resets the original map.
+func (m *Map[K, V]) CloneAndResetMap() *Map[K, V] {
+	m.mutex.Lock()
+	res := New[K, V](len(m.m))
+	res.mutex.Lock()
+
+	// Using deep copy
+	maps.Copy(res.m, m.m)
+
+	// Reset the original map
+	m.m = make(map[K]V, len(m.m))
+
+	res.mutex.Unlock()
+	m.mutex.Unlock()
 
 	return res
 }
@@ -142,4 +186,37 @@ func MapAllF[K comparable, V any, U any](m *Map[K, V], f func(map[K]V) U) U {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return f(m.m)
+}
+
+// UpdateOrInsert will update the value if it exists, otherwise it will insert the default value.
+func (mp *Map[K, V]) UpdateOrInsert(key K, updateFn func(V) V, defaultVal V) V {
+	mp.mutex.Lock()
+	defer mp.mutex.Unlock()
+
+	if currentVal, exists := mp.m[key]; exists {
+		newVal := updateFn(currentVal)
+		mp.m[key] = newVal
+		return newVal
+	} else {
+		newVal := updateFn(defaultVal)
+		mp.m[key] = newVal
+		return newVal
+	}
+}
+
+// UpdateOrInsert will update the value if it exists, otherwise it will insert the default value.
+func (mp *Map[K, V]) UpdateOrInsertFn(key K, updateFn func(V) V, defaultValFn func() V) V {
+	mp.mutex.Lock()
+	defer mp.mutex.Unlock()
+
+	if currentVal, exists := mp.m[key]; exists {
+		newVal := updateFn(currentVal)
+		mp.m[key] = newVal
+		return newVal
+	} else {
+		defaultVal := defaultValFn()
+		newVal := updateFn(defaultVal)
+		mp.m[key] = newVal
+		return newVal
+	}
 }

--- a/metadata_policy.go
+++ b/metadata_policy.go
@@ -1,0 +1,19 @@
+package aerospike
+
+type Labels struct {
+	Labels *[]map[string]string
+}
+
+func NewLabels(pairs ...map[string]string) *Labels {
+	labels := make([]map[string]string, 0)
+	for _, pairMap := range pairs {
+		if pairMap != nil || len(pairMap) > 0 {
+			labels = append(labels, pairMap)
+		}
+	}
+
+	mp := Labels{
+		Labels: &labels,
+	}
+	return &mp
+}

--- a/metrics_policy.go
+++ b/metrics_policy.go
@@ -50,6 +50,9 @@ type MetricsPolicy struct {
 	//
 	// Default: 2
 	LatencyBase int //= 2;
+
+	// Labels                  NewMetadataPolicy(map[string]string{"user":policy.User}, map[string]string{"cluster-name": policy.ClusterName}), }
+	Labels *Labels
 }
 
 func DefaultMetricsPolicy() *MetricsPolicy {
@@ -57,5 +60,27 @@ func DefaultMetricsPolicy() *MetricsPolicy {
 		HistogramType:  histogram.Logarithmic,
 		LatencyColumns: 24,
 		LatencyBase:    2,
+		Labels:         NewLabels(),
 	}
+}
+
+func DefaultMetricsPolicyWithLabels(pairs ...map[string]string) *MetricsPolicy {
+	labels := NewLabels(pairs...)
+	mp := *DefaultMetricsPolicy()
+
+	mp.Labels = labels
+
+	return &mp
+}
+
+func CopyMetricsPolicyWithLabels(mp *MetricsPolicy, pairs ...map[string]string) *MetricsPolicy {
+	mpCopy := *mp
+
+	if mpCopy.Labels == nil {
+		mpCopy.Labels = NewLabels(pairs...)
+	} else if mpCopy.Labels != nil && len(*mpCopy.Labels.Labels) == 0 {
+		mpCopy.Labels = NewLabels(pairs...)
+	}
+
+	return &mpCopy
 }

--- a/metrics_policy.go
+++ b/metrics_policy.go
@@ -51,10 +51,13 @@ type MetricsPolicy struct {
 	// Default: 2
 	LatencyBase int //= 2;
 
-	// Labels                  NewMetadataPolicy(map[string]string{"user":policy.User}, map[string]string{"cluster-name": policy.ClusterName}), }
+	// User provided labels which will appended to the metrics on export. This
+	// information is used downstream by metrics aggregetators to group/identify metrics
+	// collected by the client.
 	Labels *Labels
 }
 
+// NewMetricsPolicy creates a new MetricsPolicy with predefined set of default parameters.
 func DefaultMetricsPolicy() *MetricsPolicy {
 	return &MetricsPolicy{
 		HistogramType:  histogram.Logarithmic,
@@ -64,6 +67,8 @@ func DefaultMetricsPolicy() *MetricsPolicy {
 	}
 }
 
+// DefaultMetricsPolicyWithLabels creates a new MetricsPolicy with the provided labels.
+// The labels are used to identify the metrics collected by the client.
 func DefaultMetricsPolicyWithLabels(pairs ...map[string]string) *MetricsPolicy {
 	labels := NewLabels(pairs...)
 	mp := *DefaultMetricsPolicy()
@@ -71,16 +76,4 @@ func DefaultMetricsPolicyWithLabels(pairs ...map[string]string) *MetricsPolicy {
 	mp.Labels = labels
 
 	return &mp
-}
-
-func CopyMetricsPolicyWithLabels(mp *MetricsPolicy, pairs ...map[string]string) *MetricsPolicy {
-	mpCopy := *mp
-
-	if mpCopy.Labels == nil {
-		mpCopy.Labels = NewLabels(pairs...)
-	} else if mpCopy.Labels != nil && len(*mpCopy.Labels.Labels) == 0 {
-		mpCopy.Labels = NewLabels(pairs...)
-	}
-
-	return &mpCopy
 }

--- a/multi_command.go
+++ b/multi_command.go
@@ -16,6 +16,7 @@ package aerospike
 
 import (
 	"fmt"
+	"iter"
 	"math/rand"
 	"reflect"
 
@@ -501,7 +502,7 @@ func (cmd *baseMultiCommand) execute(ifc command) Error {
 	return cmd.baseCommand.execute(ifc)
 }
 
-func (cmd *baseMultiCommand) getNamespaces() map[string]uint64 {
+func (cmd *baseMultiCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/multi_command.go
+++ b/multi_command.go
@@ -501,7 +501,7 @@ func (cmd *baseMultiCommand) execute(ifc command) Error {
 	return cmd.baseCommand.execute(ifc)
 }
 
-func (cmd *baseMultiCommand) getNamespaces() *map[string]uint64 {
+func (cmd *baseMultiCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/multi_command.go
+++ b/multi_command.go
@@ -339,6 +339,12 @@ func (cmd *baseMultiCommand) parseRecordResults(ifc command, receiveSize int) (b
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
 
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		if resultCode != 0 && resultCode != types.PARTITION_UNAVAILABLE {
 			if resultCode == types.KEY_NOT_FOUND_ERROR || resultCode == types.FILTERED_OUT {
 				return false, nil
@@ -493,4 +499,11 @@ func (cmd *baseMultiCommand) execute(ifc command) Error {
 	****************************************************************************/
 
 	return cmd.baseCommand.execute(ifc)
+}
+
+func (cmd *baseMultiCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.namespace]++
+
+	return &response
 }

--- a/multi_command.go
+++ b/multi_command.go
@@ -501,9 +501,10 @@ func (cmd *baseMultiCommand) execute(ifc command) Error {
 	return cmd.baseCommand.execute(ifc)
 }
 
-func (cmd *baseMultiCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.namespace]++
+func (cmd *baseMultiCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *baseMultiCommand) getNamespace() *string {
+	return &cmd.namespace
 }

--- a/node.go
+++ b/node.go
@@ -159,7 +159,6 @@ func (nd *Node) Refresh(peers *peers) Error {
 		nd.refreshFailed(err)
 		return err
 	}
-
 	if err = nd.verifyPartitionGeneration(infoMap); err != nil {
 		nd.refreshFailed(err)
 		return err

--- a/node_stats.go
+++ b/node_stats.go
@@ -18,7 +18,10 @@ import (
 	"encoding/json"
 	"sync"
 
+	"github.com/aerospike/aerospike-client-go/v8/types"
+
 	iatomic "github.com/aerospike/aerospike-client-go/v8/internal/atomic"
+	amap "github.com/aerospike/aerospike-client-go/v8/internal/atomic/map"
 	hist "github.com/aerospike/aerospike-client-go/v8/types/histogram"
 )
 
@@ -26,8 +29,15 @@ import (
 // These statistics are aggregated once per tend in the cluster object
 // and then are served to the end-user.
 type nodeStats struct {
+	//(htype Type, base T, buckets int)
+	//hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
 	// TODO: Remove this lock and abstract it out using Generics
 	m sync.Mutex
+	// MetricsPolicy contains policy, default values for histograms, which are used on node_stats init time
+	metricPolicy *MetricsPolicy
+
+	// Labels sourced once at applications start and passed down to metrics when metrics are enabled
+	StatLabels *Labels `json:"labels,omitempty"`
 	// Attempts to open a connection (failed + successful)
 	ConnectionsAttempts iatomic.Int `json:"connections-attempts"`
 	// Successful attempts to open a connection
@@ -62,12 +72,10 @@ type nodeStats struct {
 	NodeAdded iatomic.Int `json:"node-added-count"`
 	// Total number of times nodes were removed from the client (not the same as actual nodes removed. Network disruptions between client and server may cause a node being dropped client-side)
 	NodeRemoved iatomic.Int `json:"node-removed-count"`
-
 	// Total number of command retries
 	TransactionRetryCount iatomic.Int `json:"transaction-retry-count"`
 	// Total number of command errors
 	TransactionErrorCount iatomic.Int `json:"transaction-error-count"`
-
 	// Metrics for Get commands
 	GetMetrics hist.SyncHistogram[uint64] `json:"get-metrics"`
 	// Metrics for GetHeader commands
@@ -90,6 +98,70 @@ type nodeStats struct {
 	BatchReadMetrics hist.SyncHistogram[uint64] `json:"batch-read-metrics"`
 	// Metrics for Batch commands containing writes
 	BatchWriteMetrics hist.SyncHistogram[uint64] `json:"batch-write-metrics"`
+	// Error counts for each command
+	DetailedResultCodeCounts amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] `json:"detailed-resultcode-counts"`
+	// Detailed metrics for per namespace and per command type
+	DetailedMetrics amap.Map[string, *amap.Map[commandType, *commandMetric]] `json:"detailed-metrics"`
+}
+
+// commandResultCodeMetric keeps track of the ResonseCode counts for a given command
+type commandResultCodeMetric struct {
+	ResultCodeCounts amap.Map[types.ResultCode, uint64] `json:"resultcode-counts"`
+}
+
+// newCommandResultCodeMetric creates a new CommandErrorMetric object
+func (n *nodeStats) newCommandResultCodeMetric() *commandResultCodeMetric {
+	return &commandResultCodeMetric{
+		ResultCodeCounts: *amap.NewWithValue[types.ResultCode, uint64](0, 0),
+	}
+}
+
+func (n *nodeStats) newCommandResultCodeMetricWithValue(resultCode types.ResultCode) *commandResultCodeMetric {
+	return &commandResultCodeMetric{
+		ResultCodeCounts: *amap.NewWithValue[types.ResultCode, uint64](resultCode, 0),
+	}
+}
+
+// commandMetric keeps track of detailed metrics for a given command
+type commandMetric struct {
+	ConnectionAq  hist.SyncHistogram[uint64] `json:"connection-aq"`
+	Latency       hist.SyncHistogram[uint64] `json:"latency"`
+	Parsing       hist.SyncHistogram[uint64] `json:"parsing"`
+	BytesSent     hist.SyncHistogram[uint64] `json:"bytes-sent"`
+	BytesReceived hist.SyncHistogram[uint64] `json:"bytes-received"`
+}
+
+// newCommandMetric creates a new CommandMetric object
+func (n *nodeStats) newCommandMetric() *commandMetric {
+	return &commandMetric{
+		ConnectionAq:  *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		Latency:       *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		Parsing:       *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		BytesSent:     *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		BytesReceived: *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+	}
+}
+
+// // Update or insert Detailed error metrics
+func (n *nodeStats) updateOrInsert(ifc command, resultCode types.ResultCode) {
+	n.m.Lock()
+	defer n.m.Unlock()
+	for namespace := range *ifc.getNamespace() {
+		n.DetailedResultCodeCounts.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+			a.UpdateOrInsertFn(ifc.commandType(), func(b *commandResultCodeMetric) *commandResultCodeMetric {
+				b.ResultCodeCounts.UpdateOrInsert(resultCode, func(c uint64) uint64 {
+					c++
+					return c
+				}, 0)
+				return b
+			}, func() *commandResultCodeMetric {
+				return n.newCommandResultCodeMetricWithValue(resultCode)
+			})
+			return a
+		}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+			return amap.NewWithValue(ifc.commandType(), n.newCommandResultCodeMetricWithValue(resultCode))
+		})
+	}
 }
 
 func newNodeStats(policy *MetricsPolicy) *nodeStats {
@@ -98,17 +170,21 @@ func newNodeStats(policy *MetricsPolicy) *nodeStats {
 	}
 
 	return &nodeStats{
-		GetMetrics:        *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		GetHeaderMetrics:  *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		ExistsMetrics:     *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		PutMetrics:        *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		DeleteMetrics:     *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		OperateMetrics:    *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		QueryMetrics:      *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		ScanMetrics:       *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		UDFMetrics:        *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		BatchReadMetrics:  *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
-		BatchWriteMetrics: *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		metricPolicy:             policy,
+		StatLabels:               NewLabels(),
+		GetMetrics:               *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		GetHeaderMetrics:         *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		ExistsMetrics:            *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		PutMetrics:               *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		DeleteMetrics:            *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		OperateMetrics:           *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		QueryMetrics:             *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		ScanMetrics:              *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		UDFMetrics:               *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		BatchReadMetrics:         *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		BatchWriteMetrics:        *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
+		DetailedResultCodeCounts: *amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0),
+		DetailedMetrics:          *amap.New[string, *amap.Map[commandType, *commandMetric]](0),
 	}
 }
 
@@ -117,6 +193,8 @@ func (ns *nodeStats) getAndReset() *nodeStats {
 	ns.m.Lock()
 
 	res := &nodeStats{
+		metricPolicy:             ns.metricPolicy,
+		StatLabels:               NewLabels(),
 		ConnectionsAttempts:      ns.ConnectionsAttempts.CloneAndSet(0),
 		ConnectionsSuccessful:    ns.ConnectionsSuccessful.CloneAndSet(0),
 		ConnectionsFailed:        ns.ConnectionsFailed.CloneAndSet(0),
@@ -138,17 +216,19 @@ func (ns *nodeStats) getAndReset() *nodeStats {
 		TransactionRetryCount: ns.TransactionRetryCount.CloneAndSet(0),
 		TransactionErrorCount: ns.TransactionErrorCount.CloneAndSet(0),
 
-		GetMetrics:        *ns.GetMetrics.CloneAndReset(),
-		GetHeaderMetrics:  *ns.GetHeaderMetrics.CloneAndReset(),
-		ExistsMetrics:     *ns.ExistsMetrics.CloneAndReset(),
-		PutMetrics:        *ns.PutMetrics.CloneAndReset(),
-		DeleteMetrics:     *ns.DeleteMetrics.CloneAndReset(),
-		OperateMetrics:    *ns.OperateMetrics.CloneAndReset(),
-		QueryMetrics:      *ns.QueryMetrics.CloneAndReset(),
-		ScanMetrics:       *ns.ScanMetrics.CloneAndReset(),
-		UDFMetrics:        *ns.UDFMetrics.CloneAndReset(),
-		BatchReadMetrics:  *ns.BatchReadMetrics.CloneAndReset(),
-		BatchWriteMetrics: *ns.BatchWriteMetrics.CloneAndReset(),
+		GetMetrics:               *ns.GetMetrics.CloneAndReset(),
+		GetHeaderMetrics:         *ns.GetHeaderMetrics.CloneAndReset(),
+		ExistsMetrics:            *ns.ExistsMetrics.CloneAndReset(),
+		PutMetrics:               *ns.PutMetrics.CloneAndReset(),
+		DeleteMetrics:            *ns.DeleteMetrics.CloneAndReset(),
+		OperateMetrics:           *ns.OperateMetrics.CloneAndReset(),
+		QueryMetrics:             *ns.QueryMetrics.CloneAndReset(),
+		ScanMetrics:              *ns.ScanMetrics.CloneAndReset(),
+		UDFMetrics:               *ns.UDFMetrics.CloneAndReset(),
+		BatchReadMetrics:         *ns.BatchReadMetrics.CloneAndReset(),
+		BatchWriteMetrics:        *ns.BatchWriteMetrics.CloneAndReset(),
+		DetailedResultCodeCounts: *ns.cloneAndResetDetailedResultCodeCounts(),
+		DetailedMetrics:          *ns.cloneAndResetDetailedMetrics(),
 	}
 
 	ns.m.Unlock()
@@ -159,6 +239,8 @@ func (ns *nodeStats) clone() nodeStats {
 	ns.m.Lock()
 
 	res := nodeStats{
+		metricPolicy:             ns.metricPolicy,
+		StatLabels:               NewLabels(),
 		ConnectionsAttempts:      ns.ConnectionsAttempts.Clone(),
 		ConnectionsSuccessful:    ns.ConnectionsSuccessful.Clone(),
 		ConnectionsFailed:        ns.ConnectionsFailed.Clone(),
@@ -180,17 +262,19 @@ func (ns *nodeStats) clone() nodeStats {
 		TransactionRetryCount: ns.TransactionRetryCount.Clone(),
 		TransactionErrorCount: ns.TransactionErrorCount.Clone(),
 
-		GetMetrics:        *ns.GetMetrics.Clone(),
-		GetHeaderMetrics:  *ns.GetHeaderMetrics.Clone(),
-		ExistsMetrics:     *ns.ExistsMetrics.Clone(),
-		PutMetrics:        *ns.PutMetrics.Clone(),
-		DeleteMetrics:     *ns.DeleteMetrics.Clone(),
-		OperateMetrics:    *ns.OperateMetrics.Clone(),
-		QueryMetrics:      *ns.QueryMetrics.Clone(),
-		ScanMetrics:       *ns.ScanMetrics.Clone(),
-		UDFMetrics:        *ns.UDFMetrics.Clone(),
-		BatchReadMetrics:  *ns.BatchReadMetrics.Clone(),
-		BatchWriteMetrics: *ns.BatchWriteMetrics.Clone(),
+		GetMetrics:               *ns.GetMetrics.Clone(),
+		GetHeaderMetrics:         *ns.GetHeaderMetrics.Clone(),
+		ExistsMetrics:            *ns.ExistsMetrics.Clone(),
+		PutMetrics:               *ns.PutMetrics.Clone(),
+		DeleteMetrics:            *ns.DeleteMetrics.Clone(),
+		OperateMetrics:           *ns.OperateMetrics.Clone(),
+		QueryMetrics:             *ns.QueryMetrics.Clone(),
+		ScanMetrics:              *ns.ScanMetrics.Clone(),
+		UDFMetrics:               *ns.UDFMetrics.Clone(),
+		BatchReadMetrics:         *ns.BatchReadMetrics.Clone(),
+		BatchWriteMetrics:        *ns.BatchWriteMetrics.Clone(),
+		DetailedResultCodeCounts: *ns.cloneDetailedResultCodeCounts(),
+		DetailedMetrics:          *ns.cloneDetailedMetrics(),
 	}
 
 	ns.m.Unlock()
@@ -199,6 +283,8 @@ func (ns *nodeStats) clone() nodeStats {
 
 func (ns *nodeStats) reshape(policy *MetricsPolicy) {
 	ns.m.Lock()
+	ns.metricPolicy = policy
+	ns.StatLabels = NewLabels()
 	ns.GetMetrics.Reshape(policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns)
 	ns.GetHeaderMetrics.Reshape(policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns)
 	ns.ExistsMetrics.Reshape(policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns)
@@ -210,6 +296,8 @@ func (ns *nodeStats) reshape(policy *MetricsPolicy) {
 	ns.UDFMetrics.Reshape(policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns)
 	ns.BatchReadMetrics.Reshape(policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns)
 	ns.BatchWriteMetrics.Reshape(policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns)
+	ns.reshapeDetailedResultCodeCounts()
+	ns.reshapeDetailedMetrics()
 	ns.m.Unlock()
 }
 
@@ -217,6 +305,7 @@ func (ns *nodeStats) aggregate(newStats *nodeStats) {
 	ns.m.Lock()
 	newStats.m.Lock()
 
+	ns.StatLabels = NewLabels()
 	ns.ConnectionsAttempts.AddAndGet(newStats.ConnectionsAttempts.Get())
 	ns.ConnectionsSuccessful.AddAndGet(newStats.ConnectionsSuccessful.Get())
 	ns.ConnectionsFailed.AddAndGet(newStats.ConnectionsFailed.Get())
@@ -249,6 +338,8 @@ func (ns *nodeStats) aggregate(newStats *nodeStats) {
 	ns.UDFMetrics.Merge(&newStats.UDFMetrics)
 	ns.BatchReadMetrics.Merge(&newStats.BatchReadMetrics)
 	ns.BatchWriteMetrics.Merge(&newStats.BatchWriteMetrics)
+	ns.mergeCommandResultCodeMetric(newStats)
+	ns.mergeDetailedMetrics(newStats)
 
 	newStats.m.Unlock()
 	ns.m.Unlock()
@@ -256,39 +347,41 @@ func (ns *nodeStats) aggregate(newStats *nodeStats) {
 
 func (ns nodeStats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		ConnectionsAttempts      int `json:"connections-attempts"`
-		ConnectionsSuccessful    int `json:"connections-successful"`
-		ConnectionsFailed        int `json:"connections-failed"`
-		ConnectionsTimeoutErrors int `json:"connections-error-timeout"`
-		ConnectionsOtherErrors   int `json:"connections-error-other"`
-		CircuitBreakerHits       int `json:"circuit-breaker-hits"`
-		ConnectionsPoolEmpty     int `json:"connections-pool-empty"`
-		ConnectionsPoolOverflow  int `json:"connections-pool-overflow"`
-		ConnectionsIdleDropped   int `json:"connections-idle-dropped"`
-		ConnectionsOpen          int `json:"open-connections"`
-		ConnectionsClosed        int `json:"closed-connections"`
-		TendsTotal               int `json:"tends-total"`
-		TendsSuccessful          int `json:"tends-successful"`
-		TendsFailed              int `json:"tends-failed"`
-		PartitionMapUpdates      int `json:"partition-map-updates"`
-		NodeAdded                int `json:"node-added-count"`
-		NodeRemoved              int `json:"node-removed-count"`
-
-		RetryCount int `json:"transaction-retry-count"`
-		ErrorCount int `json:"transaction-error-count"`
-
-		GetMetrics        hist.SyncHistogram[uint64] `json:"get-metrics"`
-		GetHeaderMetrics  hist.SyncHistogram[uint64] `json:"get-header-metrics"`
-		ExistsMetrics     hist.SyncHistogram[uint64] `json:"exists-metrics"`
-		PutMetrics        hist.SyncHistogram[uint64] `json:"put-metrics"`
-		DeleteMetrics     hist.SyncHistogram[uint64] `json:"delete-metrics"`
-		OperateMetrics    hist.SyncHistogram[uint64] `json:"operate-metrics"`
-		QueryMetrics      hist.SyncHistogram[uint64] `json:"query-metrics"`
-		ScanMetrics       hist.SyncHistogram[uint64] `json:"scan-metrics"`
-		UDFMetrics        hist.SyncHistogram[uint64] `json:"udf-metrics"`
-		BatchReadMetrics  hist.SyncHistogram[uint64] `json:"batch-read-metrics"`
-		BatchWriteMetrics hist.SyncHistogram[uint64] `json:"batch-write-metrics"`
+		StatsLabels              []map[string]string                  `json:"labels,omitempty"`
+		ConnectionsAttempts      int                                  `json:"connections-attempts"`
+		ConnectionsSuccessful    int                                  `json:"connections-successful"`
+		ConnectionsFailed        int                                  `json:"connections-failed"`
+		ConnectionsTimeoutErrors int                                  `json:"connections-error-timeout"`
+		ConnectionsOtherErrors   int                                  `json:"connections-error-other"`
+		CircuitBreakerHits       int                                  `json:"circuit-breaker-hits"`
+		ConnectionsPoolEmpty     int                                  `json:"connections-pool-empty"`
+		ConnectionsPoolOverflow  int                                  `json:"connections-pool-overflow"`
+		ConnectionsIdleDropped   int                                  `json:"connections-idle-dropped"`
+		ConnectionsOpen          int                                  `json:"open-connections"`
+		ConnectionsClosed        int                                  `json:"closed-connections"`
+		TendsTotal               int                                  `json:"tends-total"`
+		TendsSuccessful          int                                  `json:"tends-successful"`
+		TendsFailed              int                                  `json:"tends-failed"`
+		PartitionMapUpdates      int                                  `json:"partition-map-updates"`
+		NodeAdded                int                                  `json:"node-added-count"`
+		NodeRemoved              int                                  `json:"node-removed-count"`
+		RetryCount               int                                  `json:"transaction-retry-count"`
+		ErrorCount               int                                  `json:"transaction-error-count"`
+		GetMetrics               hist.SyncHistogram[uint64]           `json:"get-metrics"`
+		GetHeaderMetrics         hist.SyncHistogram[uint64]           `json:"get-header-metrics"`
+		ExistsMetrics            hist.SyncHistogram[uint64]           `json:"exists-metrics"`
+		PutMetrics               hist.SyncHistogram[uint64]           `json:"put-metrics"`
+		DeleteMetrics            hist.SyncHistogram[uint64]           `json:"delete-metrics"`
+		OperateMetrics           hist.SyncHistogram[uint64]           `json:"operate-metrics"`
+		QueryMetrics             hist.SyncHistogram[uint64]           `json:"query-metrics"`
+		ScanMetrics              hist.SyncHistogram[uint64]           `json:"scan-metrics"`
+		UDFMetrics               hist.SyncHistogram[uint64]           `json:"udf-metrics"`
+		BatchReadMetrics         hist.SyncHistogram[uint64]           `json:"batch-read-metrics"`
+		BatchWriteMetrics        hist.SyncHistogram[uint64]           `json:"batch-write-metrics"`
+		ErrorCounts              map[string]map[string]map[string]int `json:"detailed-resultcode-counts"`
+		DetailedMetrics          map[string]map[string]*commandMetric `json:"detailed-metrics"`
 	}{
+		*ns.StatLabels.Labels,
 		ns.ConnectionsAttempts.Get(),
 		ns.ConnectionsSuccessful.Get(),
 		ns.ConnectionsFailed.Get(),
@@ -321,7 +414,42 @@ func (ns nodeStats) MarshalJSON() ([]byte, error) {
 		ns.UDFMetrics,
 		ns.BatchReadMetrics,
 		ns.BatchWriteMetrics,
+		ns.marshalResultCodeCounts(),
+		ns.marshalDetailedMetrics(),
 	})
+}
+
+// Serializes DetailedMetrics for json encoding
+func (ns *nodeStats) marshalDetailedMetrics() map[string]map[string]*commandMetric {
+	result := make(map[string]map[string]*commandMetric)
+	for _, namespace := range ns.DetailedMetrics.Keys() {
+		commands := ns.DetailedMetrics.Get(namespace)
+		metrics := make(map[string]*commandMetric)
+		for _, ct := range commands.Keys() {
+			metrics[ct.String()] = commands.Get(ct)
+		}
+		result[namespace] = metrics
+	}
+	return result
+}
+
+// Serializes DetailedResultCodeCounts for json encoding
+func (ns *nodeStats) marshalResultCodeCounts() map[string]map[string]map[string]int {
+	result := make(map[string]map[string]map[string]int)
+	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
+		commands := ns.DetailedResultCodeCounts.Get(namespace)
+		commandMap := make(map[string]map[string]int)
+		for _, ct := range commands.Keys() {
+			resultCodes := ns.DetailedResultCodeCounts.Get(namespace).Get(ct)
+			resultCodeMap := make(map[string]int)
+			for _, rc := range resultCodes.ResultCodeCounts.Keys() {
+				resultCodeMap[rc.String()] = int(resultCodes.ResultCodeCounts.Get(rc))
+			}
+			commandMap[ct.String()] = resultCodeMap
+		}
+		result[namespace] = commandMap
+	}
+	return result
 }
 
 func (ns *nodeStats) UnmarshalJSON(data []byte) error {
@@ -347,17 +475,19 @@ func (ns *nodeStats) UnmarshalJSON(data []byte) error {
 		RetryCount int `json:"transaction-retry-count"`
 		ErrorCount int `json:"transaction-error-count"`
 
-		GetMetrics        hist.SyncHistogram[uint64] `json:"get-metrics"`
-		GetHeaderMetrics  hist.SyncHistogram[uint64] `json:"get-header-metrics"`
-		ExistsMetrics     hist.SyncHistogram[uint64] `json:"exists-metrics"`
-		PutMetrics        hist.SyncHistogram[uint64] `json:"put-metrics"`
-		DeleteMetrics     hist.SyncHistogram[uint64] `json:"delete-metrics"`
-		OperateMetrics    hist.SyncHistogram[uint64] `json:"operate-metrics"`
-		QueryMetrics      hist.SyncHistogram[uint64] `json:"query-metrics"`
-		ScanMetrics       hist.SyncHistogram[uint64] `json:"scan-metrics"`
-		UDFMetrics        hist.SyncHistogram[uint64] `json:"udf-metrics"`
-		BatchReadMetrics  hist.SyncHistogram[uint64] `json:"batch-read-metrics"`
-		BatchWriteMetrics hist.SyncHistogram[uint64] `json:"batch-write-metrics"`
+		GetMetrics               hist.SyncHistogram[uint64]                                         `json:"get-metrics"`
+		GetHeaderMetrics         hist.SyncHistogram[uint64]                                         `json:"get-header-metrics"`
+		ExistsMetrics            hist.SyncHistogram[uint64]                                         `json:"exists-metrics"`
+		PutMetrics               hist.SyncHistogram[uint64]                                         `json:"put-metrics"`
+		DeleteMetrics            hist.SyncHistogram[uint64]                                         `json:"delete-metrics"`
+		OperateMetrics           hist.SyncHistogram[uint64]                                         `json:"operate-metrics"`
+		QueryMetrics             hist.SyncHistogram[uint64]                                         `json:"query-metrics"`
+		ScanMetrics              hist.SyncHistogram[uint64]                                         `json:"scan-metrics"`
+		UDFMetrics               hist.SyncHistogram[uint64]                                         `json:"udf-metrics"`
+		BatchReadMetrics         hist.SyncHistogram[uint64]                                         `json:"batch-read-metrics"`
+		BatchWriteMetrics        hist.SyncHistogram[uint64]                                         `json:"batch-write-metrics"`
+		DetailedResultCodeCounts amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] `json:"detailed-resultcode-counts"`
+		DetailedMetrics          amap.Map[string, *amap.Map[commandType, *commandMetric]]           `json:"detailed-metrics"`
 	}{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -396,6 +526,190 @@ func (ns *nodeStats) UnmarshalJSON(data []byte) error {
 	ns.UDFMetrics = aux.UDFMetrics
 	ns.BatchReadMetrics = aux.BatchReadMetrics
 	ns.BatchWriteMetrics = aux.BatchWriteMetrics
+	ns.DetailedResultCodeCounts = aux.DetailedResultCodeCounts
+	ns.DetailedMetrics = aux.DetailedMetrics
 
 	return nil
+}
+
+// Clone returns a deep copy of the nodeStats DetailedMetrics object
+func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
+	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
+
+	for _, namespace := range ns.DetailedMetrics.Keys() {
+		for _, command := range ns.DetailedMetrics.Get(namespace).Keys() {
+			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandMetric) *commandMetric {
+					clonedCommand.ConnectionAq = *ns.DetailedMetrics.Get(namespace).Get(command).ConnectionAq.Clone()
+					clonedCommand.Latency = *ns.DetailedMetrics.Get(namespace).Get(command).Latency.Clone()
+					clonedCommand.Parsing = *ns.DetailedMetrics.Get(namespace).Get(command).Parsing.Clone()
+					clonedCommand.BytesSent = *ns.DetailedMetrics.Get(namespace).Get(command).BytesSent.Clone()
+					clonedCommand.BytesReceived = *ns.DetailedMetrics.Get(namespace).Get(command).BytesReceived.Clone()
+					return clonedCommand
+				}, func() *commandMetric {
+					return ns.newCommandMetric()
+				})
+				return clonedInner
+			}, func() *amap.Map[commandType, *commandMetric] {
+				return amap.NewWithValue(command, ns.newCommandMetric())
+			})
+		}
+	}
+
+	return cloned
+}
+
+// Clone returns a deep copy of the nodeStats DetailedResultCodes object
+func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] {
+	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
+
+	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
+		for _, command := range ns.DetailedResultCodeCounts.Get(namespace).Keys() {
+			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandResultCodeMetric) *commandResultCodeMetric {
+					clonedCommand.ResultCodeCounts = *ns.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.CloneMap()
+					return clonedCommand
+				}, func() *commandResultCodeMetric {
+					return ns.newCommandResultCodeMetric()
+				})
+				return clonedInner
+			}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+				return amap.NewWithValue(command, ns.newCommandResultCodeMetric())
+			})
+		}
+	}
+
+	return cloned
+}
+
+// Clone and reset returns a deep copy of the nodeStats DetailedMetrics object and resets the original
+func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
+	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
+
+	for _, namespace := range n.DetailedMetrics.Keys() {
+		for _, ct := range n.DetailedMetrics.Get(namespace).Keys() {
+			cloned.UpdateOrInsertFn(namespace, func(old *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+				old.UpdateOrInsertFn(ct, func(od *commandMetric) *commandMetric {
+					od.ConnectionAq = *n.DetailedMetrics.Get(namespace).Get(ct).ConnectionAq.CloneAndReset()
+					od.Latency = *n.DetailedMetrics.Get(namespace).Get(ct).Latency.CloneAndReset()
+					od.Parsing = *n.DetailedMetrics.Get(namespace).Get(ct).Parsing.CloneAndReset()
+					od.BytesSent = *n.DetailedMetrics.Get(namespace).Get(ct).BytesSent.CloneAndReset()
+					od.BytesReceived = *n.DetailedMetrics.Get(namespace).Get(ct).BytesReceived.CloneAndReset()
+					return od
+				}, func() *commandMetric {
+					return n.newCommandMetric()
+				})
+				return old
+			}, func() *amap.Map[commandType, *commandMetric] {
+				return amap.NewWithValue(ct, n.newCommandMetric())
+			})
+		}
+	}
+
+	return cloned
+}
+
+// Clone and reset returns a deep copy of the nodeStats DetailedResultCodes object and resets the original
+func (n *nodeStats) cloneAndResetDetailedResultCodeCounts() *amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] {
+	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
+
+	for _, namespace := range n.DetailedResultCodeCounts.Keys() {
+		for _, ct := range n.DetailedResultCodeCounts.Get(namespace).Keys() {
+			cloned.UpdateOrInsertFn(namespace, func(old *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+				old.UpdateOrInsertFn(ct, func(od *commandResultCodeMetric) *commandResultCodeMetric {
+					od.ResultCodeCounts = *n.DetailedResultCodeCounts.Get(namespace).Get(ct).ResultCodeCounts.CloneAndResetMap()
+					return od
+				}, func() *commandResultCodeMetric {
+					return n.newCommandResultCodeMetric()
+				})
+				return old
+			}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+				return amap.NewWithValue(ct, n.newCommandResultCodeMetric())
+			})
+		}
+	}
+
+	return cloned
+}
+
+// mergeDetailedMetrics merges detailed metrics from the incoming stats into the current stats.
+func (n *nodeStats) mergeDetailedMetrics(ns *nodeStats) {
+	// Going through all the metrics and merging source and target
+	for _, namespace := range ns.DetailedMetrics.Keys() {
+		nsCommandSource := ns.DetailedMetrics.Get(namespace)
+		for _, command := range nsCommandSource.Keys() {
+			// Merging namespace
+			n.DetailedMetrics.UpdateOrInsertFn(namespace, func(nNamespaceTarget *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+				// Merging command
+				nNamespaceTarget.UpdateOrInsertFn(command, func(nCommandTarget *commandMetric) *commandMetric {
+					// Merging metrics
+					nCommandTarget.ConnectionAq.Merge(&nsCommandSource.Get(command).ConnectionAq)
+					nCommandTarget.Latency.Merge(&nsCommandSource.Get(command).Latency)
+					nCommandTarget.Parsing.Merge(&nsCommandSource.Get(command).Parsing)
+					nCommandTarget.BytesSent.Merge(&nsCommandSource.Get(command).BytesSent)
+					nCommandTarget.BytesReceived.Merge(&nsCommandSource.Get(command).BytesReceived)
+					return nCommandTarget
+				}, func() *commandMetric {
+					return n.newCommandMetric()
+				})
+				return nNamespaceTarget
+			}, func() *amap.Map[commandType, *commandMetric] {
+				return amap.NewWithValue(command, n.newCommandMetric())
+			})
+		}
+	}
+}
+
+// mergeCommandResultCodeMetric merges detailed error metrics from the incoming stats into the current stats.
+func (n *nodeStats) mergeCommandResultCodeMetric(ns *nodeStats) {
+	// Going through all the response codes and merging the source and target
+	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
+		for _, cp := range ns.DetailedResultCodeCounts.Get(namespace).Keys() {
+			nsResultCodes := ns.DetailedResultCodeCounts.Get(namespace).Get(cp)
+
+			for _, resultCode := range nsResultCodes.ResultCodeCounts.Keys() {
+				// Merging namespaces
+				delta := nsResultCodes.ResultCodeCounts.Get(resultCode)
+				n.DetailedResultCodeCounts.UpdateOrInsertFn(namespace, func(nNamespaceTarget *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+					// Merging commands
+					nNamespaceTarget.UpdateOrInsertFn(cp, func(nCommandTarget *commandResultCodeMetric) *commandResultCodeMetric {
+						// Merging result code
+						nCommandTarget.ResultCodeCounts.UpdateOrInsert(resultCode, func(c uint64) uint64 {
+							return c + delta
+						}, 0)
+						return nCommandTarget
+					}, func() *commandResultCodeMetric {
+						return n.newCommandResultCodeMetricWithValue(resultCode)
+					})
+					return nNamespaceTarget
+				}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+					return amap.NewWithValue(cp, n.newCommandResultCodeMetric())
+				})
+			}
+		}
+	}
+}
+
+// reshapeDetailedMetrics reshapes the detailed metrics as defined by `hist.SyncHistogram`
+func (n *nodeStats) reshapeDetailedMetrics() {
+	for _, namespace := range n.DetailedMetrics.Keys() {
+		for _, command := range n.DetailedMetrics.Get(namespace).Keys() {
+			n.DetailedMetrics.Get(namespace).Get(command).ConnectionAq.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
+			n.DetailedMetrics.Get(namespace).Get(command).Latency.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
+			n.DetailedMetrics.Get(namespace).Get(command).Parsing.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
+			n.DetailedMetrics.Get(namespace).Get(command).BytesSent.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
+			n.DetailedMetrics.Get(namespace).Get(command).BytesReceived.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
+		}
+	}
+}
+
+// reshapeDetailedResultCodeCounts reshapes the detailed error metrics
+func (n *nodeStats) reshapeDetailedResultCodeCounts() {
+	for _, namespace := range n.DetailedResultCodeCounts.Keys() {
+		for _, command := range n.DetailedResultCodeCounts.Get(namespace).Keys() {
+			for _, resultCode := range n.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.Keys() {
+				n.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.Set(resultCode, 0)
+			}
+		}
+	}
 }

--- a/node_stats.go
+++ b/node_stats.go
@@ -124,21 +124,19 @@ func (n *nodeStats) newCommandResultCodeMetricWithValue(resultCode types.ResultC
 
 // commandMetric keeps track of detailed metrics for a given command
 type commandMetric struct {
-	ConnectionAq  hist.SyncHistogram[uint64] `json:"connection-aq"`
-	Latency       hist.SyncHistogram[uint64] `json:"latency"`
-	Parsing       hist.SyncHistogram[uint64] `json:"parsing"`
-	BytesSent     hist.SyncHistogram[uint64] `json:"bytes-sent"`
-	BytesReceived hist.SyncHistogram[uint64] `json:"bytes-received"`
+	ConnectionAq hist.SyncHistogram[uint64] `json:"connection-aq"`
+	Latency      hist.SyncHistogram[uint64] `json:"latency"`
+	Parsing      hist.SyncHistogram[uint64] `json:"parsing"`
+	BytesSent    hist.SyncHistogram[uint64] `json:"bytes-sent"`
 }
 
 // newCommandMetric creates a new CommandMetric object
 func (n *nodeStats) newCommandMetric() *commandMetric {
 	return &commandMetric{
-		ConnectionAq:  *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		Latency:       *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		Parsing:       *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		BytesSent:     *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		BytesReceived: *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		ConnectionAq: *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		Latency:      *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		Parsing:      *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		BytesSent:    *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
 	}
 }
 
@@ -146,22 +144,38 @@ func (n *nodeStats) newCommandMetric() *commandMetric {
 func (n *nodeStats) updateOrInsert(ifc command, resultCode types.ResultCode) {
 	n.m.Lock()
 	defer n.m.Unlock()
-	for namespace := range *ifc.getNamespace() {
-		n.DetailedResultCodeCounts.UpdateOrInsertFn(namespace, func(a *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
-			a.UpdateOrInsertFn(ifc.commandType(), func(b *commandResultCodeMetric) *commandResultCodeMetric {
-				b.ResultCodeCounts.UpdateOrInsert(resultCode, func(c uint64) uint64 {
-					c++
-					return c
-				}, 0)
-				return b
-			}, func() *commandResultCodeMetric {
-				return n.newCommandResultCodeMetricWithValue(resultCode)
-			})
+	namespaces := ifc.getNamespaces()
+	if namespaces != nil {
+		for namespace := range *namespaces {
+			n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
+		}
+	} else {
+		namespace := *ifc.getNamespace()
+		n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
+	}
+
+}
+
+func (n *nodeStats) updateDetailedResultCodeCounts(namespace string, ifc command, resultCode types.ResultCode) {
+	n.DetailedResultCodeCounts.UpdateOrInsertFn(namespace,
+		func(a *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+			a.UpdateOrInsertFn(ifc.commandType(),
+				func(b *commandResultCodeMetric) *commandResultCodeMetric {
+					b.ResultCodeCounts.UpdateOrInsert(resultCode,
+						func(c uint64) uint64 {
+							return c + 1
+						},
+						0)
+					return b
+				},
+				func() *commandResultCodeMetric {
+					return n.newCommandResultCodeMetricWithValue(resultCode)
+				})
 			return a
-		}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+		},
+		func() *amap.Map[commandType, *commandResultCodeMetric] {
 			return amap.NewWithValue(ifc.commandType(), n.newCommandResultCodeMetricWithValue(resultCode))
 		})
-	}
 }
 
 func newNodeStats(policy *MetricsPolicy) *nodeStats {
@@ -544,7 +558,6 @@ func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandT
 					clonedCommand.Latency = *ns.DetailedMetrics.Get(namespace).Get(command).Latency.Clone()
 					clonedCommand.Parsing = *ns.DetailedMetrics.Get(namespace).Get(command).Parsing.Clone()
 					clonedCommand.BytesSent = *ns.DetailedMetrics.Get(namespace).Get(command).BytesSent.Clone()
-					clonedCommand.BytesReceived = *ns.DetailedMetrics.Get(namespace).Get(command).BytesReceived.Clone()
 					return clonedCommand
 				}, func() *commandMetric {
 					return ns.newCommandMetric()
@@ -594,7 +607,6 @@ func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[c
 					od.Latency = *n.DetailedMetrics.Get(namespace).Get(ct).Latency.CloneAndReset()
 					od.Parsing = *n.DetailedMetrics.Get(namespace).Get(ct).Parsing.CloneAndReset()
 					od.BytesSent = *n.DetailedMetrics.Get(namespace).Get(ct).BytesSent.CloneAndReset()
-					od.BytesReceived = *n.DetailedMetrics.Get(namespace).Get(ct).BytesReceived.CloneAndReset()
 					return od
 				}, func() *commandMetric {
 					return n.newCommandMetric()
@@ -647,7 +659,6 @@ func (n *nodeStats) mergeDetailedMetrics(ns *nodeStats) {
 					nCommandTarget.Latency.Merge(&nsCommandSource.Get(command).Latency)
 					nCommandTarget.Parsing.Merge(&nsCommandSource.Get(command).Parsing)
 					nCommandTarget.BytesSent.Merge(&nsCommandSource.Get(command).BytesSent)
-					nCommandTarget.BytesReceived.Merge(&nsCommandSource.Get(command).BytesReceived)
 					return nCommandTarget
 				}, func() *commandMetric {
 					return n.newCommandMetric()
@@ -698,7 +709,6 @@ func (n *nodeStats) reshapeDetailedMetrics() {
 			n.DetailedMetrics.Get(namespace).Get(command).Latency.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
 			n.DetailedMetrics.Get(namespace).Get(command).Parsing.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
 			n.DetailedMetrics.Get(namespace).Get(command).BytesSent.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
-			n.DetailedMetrics.Get(namespace).Get(command).BytesReceived.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
 		}
 	}
 }

--- a/node_stats.go
+++ b/node_stats.go
@@ -547,25 +547,61 @@ func (ns *nodeStats) UnmarshalJSON(data []byte) error {
 }
 
 // Clone returns a deep copy of the nodeStats DetailedMetrics object
+// func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
+// 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
+
+// 	for _, namespace := range ns.DetailedMetrics.Keys() {
+// 		for _, command := range ns.DetailedMetrics.Get(namespace).Keys() {
+// 			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+// 				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandMetric) *commandMetric {
+// 					clonedCommand.ConnectionAq = *ns.DetailedMetrics.Get(namespace).Get(command).ConnectionAq.Clone()
+// 					clonedCommand.Latency = *ns.DetailedMetrics.Get(namespace).Get(command).Latency.Clone()
+// 					clonedCommand.Parsing = *ns.DetailedMetrics.Get(namespace).Get(command).Parsing.Clone()
+// 					clonedCommand.BytesSent = *ns.DetailedMetrics.Get(namespace).Get(command).BytesSent.Clone()
+// 					return clonedCommand
+// 				}, func() *commandMetric {
+// 					return ns.newCommandMetric()
+// 				})
+// 				return clonedInner
+// 			}, func() *amap.Map[commandType, *commandMetric] {
+// 				return amap.NewWithValue(command, ns.newCommandMetric())
+// 			})
+// 		}
+// 	}
+
+//		return cloned
+//	}
 func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
+	// allocate the top‐level map once
 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
 
+	// iterate each namespace
 	for _, namespace := range ns.DetailedMetrics.Keys() {
-		for _, command := range ns.DetailedMetrics.Get(namespace).Keys() {
-			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandMetric) *commandMetric {
-					clonedCommand.ConnectionAq = *ns.DetailedMetrics.Get(namespace).Get(command).ConnectionAq.Clone()
-					clonedCommand.Latency = *ns.DetailedMetrics.Get(namespace).Get(command).Latency.Clone()
-					clonedCommand.Parsing = *ns.DetailedMetrics.Get(namespace).Get(command).Parsing.Clone()
-					clonedCommand.BytesSent = *ns.DetailedMetrics.Get(namespace).Get(command).BytesSent.Clone()
-					return clonedCommand
-				}, func() *commandMetric {
-					return ns.newCommandMetric()
-				})
-				return clonedInner
-			}, func() *amap.Map[commandType, *commandMetric] {
-				return amap.NewWithValue(command, ns.newCommandMetric())
-			})
+		srcCmdMap := ns.DetailedMetrics.Get(namespace)
+
+		// iterate each commandType in that namespace
+		for _, cmdType := range srcCmdMap.Keys() {
+			srcMetric := srcCmdMap.Get(cmdType)
+
+			// get-or-create inner map for this namespace
+			tgtCmdMap := cloned.Get(namespace)
+			if tgtCmdMap == nil {
+				tgtCmdMap = amap.New[commandType, *commandMetric](0)
+				cloned.Set(namespace, tgtCmdMap)
+			}
+
+			// get-or-create the commandMetric
+			tgtMetric := tgtCmdMap.Get(cmdType)
+			if tgtMetric == nil {
+				tgtMetric = ns.newCommandMetric()
+				tgtCmdMap.Set(cmdType, tgtMetric)
+			}
+
+			// clone each field
+			tgtMetric.ConnectionAq = *srcMetric.ConnectionAq.Clone()
+			tgtMetric.Latency = *srcMetric.Latency.Clone()
+			tgtMetric.Parsing = *srcMetric.Parsing.Clone()
+			tgtMetric.BytesSent = *srcMetric.BytesSent.Clone()
 		}
 	}
 
@@ -573,22 +609,49 @@ func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandT
 }
 
 // Clone returns a deep copy of the nodeStats DetailedResultCodes object
+// func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] {
+// 	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
+
+// 	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
+// 		for _, command := range ns.DetailedResultCodeCounts.Get(namespace).Keys() {
+// 			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
+// 				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandResultCodeMetric) *commandResultCodeMetric {
+// 					clonedCommand.ResultCodeCounts = *ns.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.CloneMap()
+// 					return clonedCommand
+// 				}, func() *commandResultCodeMetric {
+// 					return ns.newCommandResultCodeMetric()
+// 				})
+// 				return clonedInner
+// 			}, func() *amap.Map[commandType, *commandResultCodeMetric] {
+// 				return amap.NewWithValue(command, ns.newCommandResultCodeMetric())
+// 			})
+// 		}
+// 	}
+
+//		return cloned
+//	}
 func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] {
 	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
 
 	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
-		for _, command := range ns.DetailedResultCodeCounts.Get(namespace).Keys() {
-			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
-				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandResultCodeMetric) *commandResultCodeMetric {
-					clonedCommand.ResultCodeCounts = *ns.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.CloneMap()
-					return clonedCommand
-				}, func() *commandResultCodeMetric {
-					return ns.newCommandResultCodeMetric()
-				})
-				return clonedInner
-			}, func() *amap.Map[commandType, *commandResultCodeMetric] {
-				return amap.NewWithValue(command, ns.newCommandResultCodeMetric())
-			})
+		srcInner := ns.DetailedResultCodeCounts.Get(namespace)
+
+		for _, ct := range srcInner.Keys() {
+			srcMetric := srcInner.Get(ct)
+
+			tgtInner := cloned.Get(namespace)
+			if tgtInner == nil {
+				tgtInner = amap.New[commandType, *commandResultCodeMetric](0)
+				cloned.Set(namespace, tgtInner)
+			}
+
+			tgtMetric := tgtInner.Get(ct)
+			if tgtMetric == nil {
+				tgtMetric = ns.newCommandResultCodeMetric()
+				tgtInner.Set(ct, tgtMetric)
+			}
+
+			tgtMetric.ResultCodeCounts = *srcMetric.ResultCodeCounts.CloneMap()
 		}
 	}
 
@@ -596,25 +659,67 @@ func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map
 }
 
 // Clone and reset returns a deep copy of the nodeStats DetailedMetrics object and resets the original
+// func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
+// 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
+
+// 	for _, namespace := range n.DetailedMetrics.Keys() {
+// 		for _, ct := range n.DetailedMetrics.Get(namespace).Keys() {
+// 			cloned.UpdateOrInsertFn(namespace, func(old *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
+// 				old.UpdateOrInsertFn(ct, func(od *commandMetric) *commandMetric {
+// 					od.ConnectionAq = *n.DetailedMetrics.Get(namespace).Get(ct).ConnectionAq.CloneAndReset()
+// 					od.Latency = *n.DetailedMetrics.Get(namespace).Get(ct).Latency.CloneAndReset()
+// 					od.Parsing = *n.DetailedMetrics.Get(namespace).Get(ct).Parsing.CloneAndReset()
+// 					od.BytesSent = *n.DetailedMetrics.Get(namespace).Get(ct).BytesSent.CloneAndReset()
+// 					return od
+// 				}, func() *commandMetric {
+// 					return n.newCommandMetric()
+// 				})
+// 				return old
+// 			}, func() *amap.Map[commandType, *commandMetric] {
+// 				return amap.NewWithValue(ct, n.newCommandMetric())
+// 			})
+// 		}
+// 	}
+
+//		return cloned
+//	}
 func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
+	// one allocation for the top-level map
 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
 
+	// walk every namespace
 	for _, namespace := range n.DetailedMetrics.Keys() {
-		for _, ct := range n.DetailedMetrics.Get(namespace).Keys() {
-			cloned.UpdateOrInsertFn(namespace, func(old *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-				old.UpdateOrInsertFn(ct, func(od *commandMetric) *commandMetric {
-					od.ConnectionAq = *n.DetailedMetrics.Get(namespace).Get(ct).ConnectionAq.CloneAndReset()
-					od.Latency = *n.DetailedMetrics.Get(namespace).Get(ct).Latency.CloneAndReset()
-					od.Parsing = *n.DetailedMetrics.Get(namespace).Get(ct).Parsing.CloneAndReset()
-					od.BytesSent = *n.DetailedMetrics.Get(namespace).Get(ct).BytesSent.CloneAndReset()
-					return od
-				}, func() *commandMetric {
-					return n.newCommandMetric()
-				})
-				return old
-			}, func() *amap.Map[commandType, *commandMetric] {
-				return amap.NewWithValue(ct, n.newCommandMetric())
-			})
+		srcCmdMap := n.DetailedMetrics.Get(namespace)
+
+		// walk every commandType in that namespace
+		for _, cmdType := range srcCmdMap.Keys() {
+			srcMetric := srcCmdMap.Get(cmdType)
+
+			// clone+reset each metric (allocates inside CloneAndReset)
+			connClone := srcMetric.ConnectionAq.CloneAndReset()
+			latencyClone := srcMetric.Latency.CloneAndReset()
+			parsingClone := srcMetric.Parsing.CloneAndReset()
+			bytesClone := srcMetric.BytesSent.CloneAndReset()
+
+			// get-or-create inner map for this namespace
+			tgtCmdMap := cloned.Get(namespace)
+			if tgtCmdMap == nil {
+				tgtCmdMap = amap.New[commandType, *commandMetric](0)
+				cloned.Set(namespace, tgtCmdMap)
+			}
+
+			// get-or-create the commandMetric
+			tgtMetric := tgtCmdMap.Get(cmdType)
+			if tgtMetric == nil {
+				tgtMetric = n.newCommandMetric()
+				tgtCmdMap.Set(cmdType, tgtMetric)
+			}
+
+			// overwrite its fields with the cloned-and-reset values
+			tgtMetric.ConnectionAq = *connClone
+			tgtMetric.Latency = *latencyClone
+			tgtMetric.Parsing = *parsingClone
+			tgtMetric.BytesSent = *bytesClone
 		}
 	}
 
@@ -626,18 +731,26 @@ func (n *nodeStats) cloneAndResetDetailedResultCodeCounts() *amap.Map[string, *a
 	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
 
 	for _, namespace := range n.DetailedResultCodeCounts.Keys() {
-		for _, ct := range n.DetailedResultCodeCounts.Get(namespace).Keys() {
-			cloned.UpdateOrInsertFn(namespace, func(old *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
-				old.UpdateOrInsertFn(ct, func(od *commandResultCodeMetric) *commandResultCodeMetric {
-					od.ResultCodeCounts = *n.DetailedResultCodeCounts.Get(namespace).Get(ct).ResultCodeCounts.CloneAndResetMap()
-					return od
-				}, func() *commandResultCodeMetric {
-					return n.newCommandResultCodeMetric()
-				})
-				return old
-			}, func() *amap.Map[commandType, *commandResultCodeMetric] {
-				return amap.NewWithValue(ct, n.newCommandResultCodeMetric())
-			})
+		srcInner := n.DetailedResultCodeCounts.Get(namespace)
+
+		for _, ct := range srcInner.Keys() {
+			srcMetric := srcInner.Get(ct)
+
+			resetMap := srcMetric.ResultCodeCounts.CloneAndResetMap()
+
+			tgtInner := cloned.Get(namespace)
+			if tgtInner == nil {
+				tgtInner = amap.New[commandType, *commandResultCodeMetric](0)
+				cloned.Set(namespace, tgtInner)
+			}
+
+			tgtMetric := tgtInner.Get(ct)
+			if tgtMetric == nil {
+				tgtMetric = n.newCommandResultCodeMetric()
+				tgtInner.Set(ct, tgtMetric)
+			}
+
+			tgtMetric.ResultCodeCounts = *resetMap
 		}
 	}
 
@@ -646,56 +759,61 @@ func (n *nodeStats) cloneAndResetDetailedResultCodeCounts() *amap.Map[string, *a
 
 // mergeDetailedMetrics merges detailed metrics from the incoming stats into the current stats.
 func (n *nodeStats) mergeDetailedMetrics(ns *nodeStats) {
-	// Going through all the metrics and merging source and target
 	for _, namespace := range ns.DetailedMetrics.Keys() {
-		nsCommandSource := ns.DetailedMetrics.Get(namespace)
-		for _, command := range nsCommandSource.Keys() {
-			// Merging namespace
-			n.DetailedMetrics.UpdateOrInsertFn(namespace, func(nNamespaceTarget *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-				// Merging command
-				nNamespaceTarget.UpdateOrInsertFn(command, func(nCommandTarget *commandMetric) *commandMetric {
-					// Merging metrics
-					nCommandTarget.ConnectionAq.Merge(&nsCommandSource.Get(command).ConnectionAq)
-					nCommandTarget.Latency.Merge(&nsCommandSource.Get(command).Latency)
-					nCommandTarget.Parsing.Merge(&nsCommandSource.Get(command).Parsing)
-					nCommandTarget.BytesSent.Merge(&nsCommandSource.Get(command).BytesSent)
-					return nCommandTarget
-				}, func() *commandMetric {
-					return n.newCommandMetric()
-				})
-				return nNamespaceTarget
-			}, func() *amap.Map[commandType, *commandMetric] {
-				return amap.NewWithValue(command, n.newCommandMetric())
-			})
+		srcCmdMap := ns.DetailedMetrics.Get(namespace)
+
+		tgtCmdMap := n.DetailedMetrics.Get(namespace)
+		if tgtCmdMap == nil {
+			tgtCmdMap = amap.New[commandType, *commandMetric](0)
+			n.DetailedMetrics.Set(namespace, tgtCmdMap)
+		}
+
+		for _, cmdType := range srcCmdMap.Keys() {
+			srcMetric := srcCmdMap.Get(cmdType)
+
+			tgtMetric := tgtCmdMap.Get(cmdType)
+			if tgtMetric == nil {
+				tgtMetric = n.newCommandMetric()
+				tgtCmdMap.Set(cmdType, tgtMetric)
+			}
+
+			tgtMetric.ConnectionAq.Merge(&srcMetric.ConnectionAq)
+			tgtMetric.Latency.Merge(&srcMetric.Latency)
+			tgtMetric.Parsing.Merge(&srcMetric.Parsing)
+			tgtMetric.BytesSent.Merge(&srcMetric.BytesSent)
 		}
 	}
 }
 
 // mergeCommandResultCodeMetric merges detailed error metrics from the incoming stats into the current stats.
 func (n *nodeStats) mergeCommandResultCodeMetric(ns *nodeStats) {
-	// Going through all the response codes and merging the source and target
 	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
-		for _, cp := range ns.DetailedResultCodeCounts.Get(namespace).Keys() {
-			nsResultCodes := ns.DetailedResultCodeCounts.Get(namespace).Get(cp)
+		srcNSMap := ns.DetailedResultCodeCounts.Get(namespace)
 
-			for _, resultCode := range nsResultCodes.ResultCodeCounts.Keys() {
-				// Merging namespaces
-				delta := nsResultCodes.ResultCodeCounts.Get(resultCode)
-				n.DetailedResultCodeCounts.UpdateOrInsertFn(namespace, func(nNamespaceTarget *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
-					// Merging commands
-					nNamespaceTarget.UpdateOrInsertFn(cp, func(nCommandTarget *commandResultCodeMetric) *commandResultCodeMetric {
-						// Merging result code
-						nCommandTarget.ResultCodeCounts.UpdateOrInsert(resultCode, func(c uint64) uint64 {
-							return c + delta
-						}, 0)
-						return nCommandTarget
-					}, func() *commandResultCodeMetric {
-						return n.newCommandResultCodeMetricWithValue(resultCode)
-					})
-					return nNamespaceTarget
-				}, func() *amap.Map[commandType, *commandResultCodeMetric] {
-					return amap.NewWithValue(cp, n.newCommandResultCodeMetric())
-				})
+		// get-or-create the target inner map for this namespace
+		tgtNSMap := n.DetailedResultCodeCounts.Get(namespace)
+		if tgtNSMap == nil {
+			tgtNSMap = amap.New[commandType, *commandResultCodeMetric](0)
+			n.DetailedResultCodeCounts.Set(namespace, tgtNSMap)
+		}
+
+		// for each commandType in that namespace
+		for _, cp := range srcNSMap.Keys() {
+			srcMetric := srcNSMap.Get(cp)
+
+			tgtMetric := tgtNSMap.Get(cp)
+			if tgtMetric == nil {
+				tgtMetric = n.newCommandResultCodeMetric()
+				tgtNSMap.Set(cp, tgtMetric)
+			}
+
+			for _, resultCode := range srcMetric.ResultCodeCounts.Keys() {
+				delta := srcMetric.ResultCodeCounts.Get(resultCode)
+				if cur := tgtMetric.ResultCodeCounts.Get(resultCode); cur > 0 {
+					tgtMetric.ResultCodeCounts.Set(resultCode, cur+delta)
+				} else {
+					tgtMetric.ResultCodeCounts.Set(resultCode, delta)
+				}
 			}
 		}
 	}

--- a/node_stats.go
+++ b/node_stats.go
@@ -104,22 +104,9 @@ type nodeStats struct {
 	DetailedMetrics amap.Map[string, *amap.Map[commandType, *commandMetric]] `json:"detailed-metrics"`
 }
 
-// commandResultCodeMetric keeps track of the ResonseCode counts for a given command
+// commandResultCodeMetric keeps track of the ResultCode counts for a given command
 type commandResultCodeMetric struct {
 	ResultCodeCounts amap.Map[types.ResultCode, uint64] `json:"resultcode-counts"`
-}
-
-// newCommandResultCodeMetric creates a new CommandErrorMetric object
-func (n *nodeStats) newCommandResultCodeMetric() *commandResultCodeMetric {
-	return &commandResultCodeMetric{
-		ResultCodeCounts: *amap.NewWithValue[types.ResultCode, uint64](0, 0),
-	}
-}
-
-func (n *nodeStats) newCommandResultCodeMetricWithValue(resultCode types.ResultCode) *commandResultCodeMetric {
-	return &commandResultCodeMetric{
-		ResultCodeCounts: *amap.NewWithValue[types.ResultCode, uint64](resultCode, 0),
-	}
 }
 
 // commandMetric keeps track of detailed metrics for a given command
@@ -140,44 +127,7 @@ func (n *nodeStats) newCommandMetric() *commandMetric {
 	}
 }
 
-// // Update or insert Detailed error metrics
-func (n *nodeStats) updateOrInsert(ifc command, resultCode types.ResultCode) {
-	n.m.Lock()
-	defer n.m.Unlock()
-	namespaces := ifc.getNamespaces()
-	if namespaces != nil {
-		for namespace := range *namespaces {
-			n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
-		}
-	} else {
-		namespace := *ifc.getNamespace()
-		n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
-	}
-
-}
-
-func (n *nodeStats) updateDetailedResultCodeCounts(namespace string, ifc command, resultCode types.ResultCode) {
-	n.DetailedResultCodeCounts.UpdateOrInsertFn(namespace,
-		func(a *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
-			a.UpdateOrInsertFn(ifc.commandType(),
-				func(b *commandResultCodeMetric) *commandResultCodeMetric {
-					b.ResultCodeCounts.UpdateOrInsert(resultCode,
-						func(c uint64) uint64 {
-							return c + 1
-						},
-						0)
-					return b
-				},
-				func() *commandResultCodeMetric {
-					return n.newCommandResultCodeMetricWithValue(resultCode)
-				})
-			return a
-		},
-		func() *amap.Map[commandType, *commandResultCodeMetric] {
-			return amap.NewWithValue(ifc.commandType(), n.newCommandResultCodeMetricWithValue(resultCode))
-		})
-}
-
+// newNodeStats creates a new NodeStats object
 func newNodeStats(policy *MetricsPolicy) *nodeStats {
 	if policy == nil {
 		policy = DefaultMetricsPolicy()
@@ -199,6 +149,20 @@ func newNodeStats(policy *MetricsPolicy) *nodeStats {
 		BatchWriteMetrics:        *hist.NewSync[uint64](policy.HistogramType, uint64(policy.LatencyBase), policy.LatencyColumns),
 		DetailedResultCodeCounts: *amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0),
 		DetailedMetrics:          *amap.New[string, *amap.Map[commandType, *commandMetric]](0),
+	}
+}
+
+// newCommandResultCodeMetric creates a new CommandErrorMetric object
+func (n *nodeStats) newCommandResultCodeMetric() *commandResultCodeMetric {
+	return &commandResultCodeMetric{
+		ResultCodeCounts: *amap.NewWithValue[types.ResultCode, uint64](0, 0),
+	}
+}
+
+// newCommandResultCodeMetricWithValue creates a new CommandErrorMetric object with the given ResultCode
+func (n *nodeStats) newCommandResultCodeMetricWithValue(resultCode types.ResultCode) *commandResultCodeMetric {
+	return &commandResultCodeMetric{
+		ResultCodeCounts: *amap.NewWithValue[types.ResultCode, uint64](resultCode, 0),
 	}
 }
 
@@ -547,30 +511,6 @@ func (ns *nodeStats) UnmarshalJSON(data []byte) error {
 }
 
 // Clone returns a deep copy of the nodeStats DetailedMetrics object
-// func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
-// 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
-
-// 	for _, namespace := range ns.DetailedMetrics.Keys() {
-// 		for _, command := range ns.DetailedMetrics.Get(namespace).Keys() {
-// 			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-// 				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandMetric) *commandMetric {
-// 					clonedCommand.ConnectionAq = *ns.DetailedMetrics.Get(namespace).Get(command).ConnectionAq.Clone()
-// 					clonedCommand.Latency = *ns.DetailedMetrics.Get(namespace).Get(command).Latency.Clone()
-// 					clonedCommand.Parsing = *ns.DetailedMetrics.Get(namespace).Get(command).Parsing.Clone()
-// 					clonedCommand.BytesSent = *ns.DetailedMetrics.Get(namespace).Get(command).BytesSent.Clone()
-// 					return clonedCommand
-// 				}, func() *commandMetric {
-// 					return ns.newCommandMetric()
-// 				})
-// 				return clonedInner
-// 			}, func() *amap.Map[commandType, *commandMetric] {
-// 				return amap.NewWithValue(command, ns.newCommandMetric())
-// 			})
-// 		}
-// 	}
-
-//		return cloned
-//	}
 func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
 	// allocate the top‐level map once
 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
@@ -609,27 +549,6 @@ func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandT
 }
 
 // Clone returns a deep copy of the nodeStats DetailedResultCodes object
-// func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] {
-// 	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
-
-// 	for _, namespace := range ns.DetailedResultCodeCounts.Keys() {
-// 		for _, command := range ns.DetailedResultCodeCounts.Get(namespace).Keys() {
-// 			cloned.UpdateOrInsertFn(namespace, func(clonedInner *amap.Map[commandType, *commandResultCodeMetric]) *amap.Map[commandType, *commandResultCodeMetric] {
-// 				clonedInner.UpdateOrInsertFn(command, func(clonedCommand *commandResultCodeMetric) *commandResultCodeMetric {
-// 					clonedCommand.ResultCodeCounts = *ns.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.CloneMap()
-// 					return clonedCommand
-// 				}, func() *commandResultCodeMetric {
-// 					return ns.newCommandResultCodeMetric()
-// 				})
-// 				return clonedInner
-// 			}, func() *amap.Map[commandType, *commandResultCodeMetric] {
-// 				return amap.NewWithValue(command, ns.newCommandResultCodeMetric())
-// 			})
-// 		}
-// 	}
-
-//		return cloned
-//	}
 func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map[commandType, *commandResultCodeMetric]] {
 	cloned := amap.New[string, *amap.Map[commandType, *commandResultCodeMetric]](0)
 
@@ -659,30 +578,6 @@ func (ns *nodeStats) cloneDetailedResultCodeCounts() *amap.Map[string, *amap.Map
 }
 
 // Clone and reset returns a deep copy of the nodeStats DetailedMetrics object and resets the original
-// func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
-// 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
-
-// 	for _, namespace := range n.DetailedMetrics.Keys() {
-// 		for _, ct := range n.DetailedMetrics.Get(namespace).Keys() {
-// 			cloned.UpdateOrInsertFn(namespace, func(old *amap.Map[commandType, *commandMetric]) *amap.Map[commandType, *commandMetric] {
-// 				old.UpdateOrInsertFn(ct, func(od *commandMetric) *commandMetric {
-// 					od.ConnectionAq = *n.DetailedMetrics.Get(namespace).Get(ct).ConnectionAq.CloneAndReset()
-// 					od.Latency = *n.DetailedMetrics.Get(namespace).Get(ct).Latency.CloneAndReset()
-// 					od.Parsing = *n.DetailedMetrics.Get(namespace).Get(ct).Parsing.CloneAndReset()
-// 					od.BytesSent = *n.DetailedMetrics.Get(namespace).Get(ct).BytesSent.CloneAndReset()
-// 					return od
-// 				}, func() *commandMetric {
-// 					return n.newCommandMetric()
-// 				})
-// 				return old
-// 			}, func() *amap.Map[commandType, *commandMetric] {
-// 				return amap.NewWithValue(ct, n.newCommandMetric())
-// 			})
-// 		}
-// 	}
-
-//		return cloned
-//	}
 func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[commandType, *commandMetric]] {
 	// one allocation for the top-level map
 	cloned := amap.New[string, *amap.Map[commandType, *commandMetric]](0)
@@ -839,5 +734,43 @@ func (n *nodeStats) reshapeDetailedResultCodeCounts() {
 				n.DetailedResultCodeCounts.Get(namespace).Get(command).ResultCodeCounts.Set(resultCode, 0)
 			}
 		}
+	}
+}
+
+// Update or insert Detailed error metrics
+func (n *nodeStats) updateOrInsert(ifc command, resultCode types.ResultCode) {
+	n.m.Lock()
+	defer n.m.Unlock()
+	namespaces := ifc.getNamespaces()
+	if namespaces != nil {
+		for namespace := range *namespaces {
+			n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
+		}
+	} else {
+		namespace := *ifc.getNamespace()
+		n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
+	}
+
+}
+
+// Update or insert result code counts for a specific namespace and command type
+func (n *nodeStats) updateDetailedResultCodeCounts(namespace string, ifc command, resultCode types.ResultCode) {
+	inner := n.DetailedResultCodeCounts.Get(namespace)
+	if inner == nil {
+		inner = amap.New[commandType, *commandResultCodeMetric](0)
+		n.DetailedResultCodeCounts.Set(namespace, inner)
+	}
+
+	ct := ifc.commandType()
+	m := inner.Get(ct)
+	if m == nil {
+		m = n.newCommandResultCodeMetricWithValue(resultCode)
+		inner.Set(ct, m)
+	}
+
+	if cur := m.ResultCodeCounts.Get(resultCode); cur > 0 {
+		m.ResultCodeCounts.Set(resultCode, cur+1)
+	} else {
+		m.ResultCodeCounts.Set(resultCode, 1)
 	}
 }

--- a/node_stats.go
+++ b/node_stats.go
@@ -111,19 +111,21 @@ type commandResultCodeMetric struct {
 
 // commandMetric keeps track of detailed metrics for a given command
 type commandMetric struct {
-	ConnectionAq hist.SyncHistogram[uint64] `json:"connection-aq"`
-	Latency      hist.SyncHistogram[uint64] `json:"latency"`
-	Parsing      hist.SyncHistogram[uint64] `json:"parsing"`
-	BytesSent    hist.SyncHistogram[uint64] `json:"bytes-sent"`
+	ConnectionAq  hist.SyncHistogram[uint64] `json:"connection-aq"`
+	Latency       hist.SyncHistogram[uint64] `json:"latency"`
+	Parsing       hist.SyncHistogram[uint64] `json:"parsing"`
+	BytesSent     hist.SyncHistogram[uint64] `json:"bytes-sent"`
+	BytesReceived hist.SyncHistogram[uint64] `json:"bytes-received"`
 }
 
 // newCommandMetric creates a new CommandMetric object
 func (n *nodeStats) newCommandMetric() *commandMetric {
 	return &commandMetric{
-		ConnectionAq: *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		Latency:      *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		Parsing:      *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
-		BytesSent:    *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		ConnectionAq:  *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		Latency:       *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		Parsing:       *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		BytesSent:     *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
+		BytesReceived: *hist.NewSync[uint64](n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns),
 	}
 }
 
@@ -542,6 +544,7 @@ func (ns *nodeStats) cloneDetailedMetrics() *amap.Map[string, *amap.Map[commandT
 			tgtMetric.Latency = *srcMetric.Latency.Clone()
 			tgtMetric.Parsing = *srcMetric.Parsing.Clone()
 			tgtMetric.BytesSent = *srcMetric.BytesSent.Clone()
+			tgtMetric.BytesReceived = *srcMetric.BytesReceived.Clone()
 		}
 	}
 
@@ -595,6 +598,7 @@ func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[c
 			latencyClone := srcMetric.Latency.CloneAndReset()
 			parsingClone := srcMetric.Parsing.CloneAndReset()
 			bytesClone := srcMetric.BytesSent.CloneAndReset()
+			bytesReceivedClone := srcMetric.BytesReceived.CloneAndReset()
 
 			// get-or-create inner map for this namespace
 			tgtCmdMap := cloned.Get(namespace)
@@ -615,6 +619,7 @@ func (n *nodeStats) cloneAndResetDetailedMetrics() *amap.Map[string, *amap.Map[c
 			tgtMetric.Latency = *latencyClone
 			tgtMetric.Parsing = *parsingClone
 			tgtMetric.BytesSent = *bytesClone
+			tgtMetric.BytesReceived = *bytesReceivedClone
 		}
 	}
 
@@ -676,6 +681,7 @@ func (n *nodeStats) mergeDetailedMetrics(ns *nodeStats) {
 			tgtMetric.Latency.Merge(&srcMetric.Latency)
 			tgtMetric.Parsing.Merge(&srcMetric.Parsing)
 			tgtMetric.BytesSent.Merge(&srcMetric.BytesSent)
+			tgtMetric.BytesReceived.Merge(&srcMetric.BytesReceived)
 		}
 	}
 }
@@ -722,6 +728,7 @@ func (n *nodeStats) reshapeDetailedMetrics() {
 			n.DetailedMetrics.Get(namespace).Get(command).Latency.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
 			n.DetailedMetrics.Get(namespace).Get(command).Parsing.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
 			n.DetailedMetrics.Get(namespace).Get(command).BytesSent.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
+			n.DetailedMetrics.Get(namespace).Get(command).BytesReceived.Reshape(n.metricPolicy.HistogramType, uint64(n.metricPolicy.LatencyBase), n.metricPolicy.LatencyColumns)
 		}
 	}
 }
@@ -741,36 +748,47 @@ func (n *nodeStats) reshapeDetailedResultCodeCounts() {
 func (n *nodeStats) updateOrInsert(ifc command, resultCode types.ResultCode) {
 	n.m.Lock()
 	defer n.m.Unlock()
-	namespaces := ifc.getNamespaces()
-	if namespaces != nil {
-		for namespace := range *namespaces {
-			n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
+	namespace := ifc.getNamespace()
+	if namespace != nil {
+		inner := n.DetailedResultCodeCounts.Get(*namespace)
+		if inner == nil {
+			inner = amap.New[commandType, *commandResultCodeMetric](0)
+			n.DetailedResultCodeCounts.Set(*namespace, inner)
+		}
+
+		ct := ifc.commandType()
+		m := inner.Get(ct)
+		if m == nil {
+			m = n.newCommandResultCodeMetricWithValue(resultCode)
+			inner.Set(ct, m)
+		}
+
+		if cur := m.ResultCodeCounts.Get(resultCode); cur > 0 {
+			m.ResultCodeCounts.Set(resultCode, cur+1)
+		} else {
+			m.ResultCodeCounts.Set(resultCode, 1)
 		}
 	} else {
-		namespace := *ifc.getNamespace()
-		n.updateDetailedResultCodeCounts(namespace, ifc, resultCode)
-	}
+		namespaces := ifc.getNamespaces()
+		for namespace := range namespaces {
+			inner := n.DetailedResultCodeCounts.Get(namespace)
+			if inner == nil {
+				inner = amap.New[commandType, *commandResultCodeMetric](0)
+				n.DetailedResultCodeCounts.Set(namespace, inner)
+			}
 
-}
+			ct := ifc.commandType()
+			m := inner.Get(ct)
+			if m == nil {
+				m = n.newCommandResultCodeMetricWithValue(resultCode)
+				inner.Set(ct, m)
+			}
 
-// Update or insert result code counts for a specific namespace and command type
-func (n *nodeStats) updateDetailedResultCodeCounts(namespace string, ifc command, resultCode types.ResultCode) {
-	inner := n.DetailedResultCodeCounts.Get(namespace)
-	if inner == nil {
-		inner = amap.New[commandType, *commandResultCodeMetric](0)
-		n.DetailedResultCodeCounts.Set(namespace, inner)
-	}
-
-	ct := ifc.commandType()
-	m := inner.Get(ct)
-	if m == nil {
-		m = n.newCommandResultCodeMetricWithValue(resultCode)
-		inner.Set(ct, m)
-	}
-
-	if cur := m.ResultCodeCounts.Get(resultCode); cur > 0 {
-		m.ResultCodeCounts.Set(resultCode, cur+1)
-	} else {
-		m.ResultCodeCounts.Set(resultCode, 1)
+			if cur := m.ResultCodeCounts.Get(resultCode); cur > 0 {
+				m.ResultCodeCounts.Set(resultCode, cur+1)
+			} else {
+				m.ResultCodeCounts.Set(resultCode, 1)
+			}
+		}
 	}
 }

--- a/operate_command_read.go
+++ b/operate_command_read.go
@@ -48,7 +48,7 @@ func (cmd *operateCommandRead) commandType() commandType {
 	return ttOperate
 }
 
-func (cmd *operateCommandRead) getNamespaces() *map[string]uint64 {
+func (cmd *operateCommandRead) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/operate_command_read.go
+++ b/operate_command_read.go
@@ -47,3 +47,10 @@ func (cmd *operateCommandRead) Execute() Error {
 func (cmd *operateCommandRead) commandType() commandType {
 	return ttOperate
 }
+
+func (cmd *operateCommandRead) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64)
+	response[cmd.key.namespace]++
+
+	return &response
+}

--- a/operate_command_read.go
+++ b/operate_command_read.go
@@ -14,6 +14,8 @@
 
 package aerospike
 
+import "iter"
+
 type operateCommandRead struct {
 	readCommand
 
@@ -48,7 +50,7 @@ func (cmd *operateCommandRead) commandType() commandType {
 	return ttOperate
 }
 
-func (cmd *operateCommandRead) getNamespaces() map[string]uint64 {
+func (cmd *operateCommandRead) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/operate_command_read.go
+++ b/operate_command_read.go
@@ -48,9 +48,10 @@ func (cmd *operateCommandRead) commandType() commandType {
 	return ttOperate
 }
 
-func (cmd *operateCommandRead) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64)
-	response[cmd.key.namespace]++
+func (cmd *operateCommandRead) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *operateCommandRead) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/operate_command_write.go
+++ b/operate_command_write.go
@@ -49,6 +49,12 @@ func (cmd *operateCommandWrite) parseResult(ifc command, conn *Connection) Error
 		return err
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	switch rp.resultCode {
 	case types.OK:
 		var err Error
@@ -76,4 +82,11 @@ func (cmd *operateCommandWrite) commandType() commandType {
 
 func (cmd *operateCommandWrite) GetRecord() *Record {
 	return cmd.record
+}
+
+func (cmd *operateCommandWrite) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/operate_command_write.go
+++ b/operate_command_write.go
@@ -84,7 +84,7 @@ func (cmd *operateCommandWrite) GetRecord() *Record {
 	return cmd.record
 }
 
-func (cmd *operateCommandWrite) getNamespaces() *map[string]uint64 {
+func (cmd *operateCommandWrite) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/operate_command_write.go
+++ b/operate_command_write.go
@@ -84,9 +84,10 @@ func (cmd *operateCommandWrite) GetRecord() *Record {
 	return cmd.record
 }
 
-func (cmd *operateCommandWrite) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *operateCommandWrite) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *operateCommandWrite) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/operate_command_write.go
+++ b/operate_command_write.go
@@ -14,7 +14,11 @@
 
 package aerospike
 
-import "github.com/aerospike/aerospike-client-go/v8/types"
+import (
+	"iter"
+
+	"github.com/aerospike/aerospike-client-go/v8/types"
+)
 
 type operateCommandWrite struct {
 	baseWriteCommand
@@ -84,7 +88,7 @@ func (cmd *operateCommandWrite) GetRecord() *Record {
 	return cmd.record
 }
 
-func (cmd *operateCommandWrite) getNamespaces() map[string]uint64 {
+func (cmd *operateCommandWrite) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/query_aggregate_command.go
+++ b/query_aggregate_command.go
@@ -160,7 +160,7 @@ func (cmd *queryAggregateCommand) parseRecordResults(ifc command, receiveSize in
 	return true, nil
 }
 
-func (cmd *queryAggregateCommand) getNamespaces() *map[string]uint64 {
+func (cmd *queryAggregateCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/query_aggregate_command.go
+++ b/query_aggregate_command.go
@@ -18,6 +18,7 @@ package aerospike
 
 import (
 	"fmt"
+	"iter"
 
 	"github.com/aerospike/aerospike-client-go/v8/types"
 
@@ -160,7 +161,7 @@ func (cmd *queryAggregateCommand) parseRecordResults(ifc command, receiveSize in
 	return true, nil
 }
 
-func (cmd *queryAggregateCommand) getNamespaces() map[string]uint64 {
+func (cmd *queryAggregateCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/query_aggregate_command.go
+++ b/query_aggregate_command.go
@@ -160,9 +160,10 @@ func (cmd *queryAggregateCommand) parseRecordResults(ifc command, receiveSize in
 	return true, nil
 }
 
-func (cmd *queryAggregateCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.statement.Namespace]++
+func (cmd *queryAggregateCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *queryAggregateCommand) getNamespace() *string {
+	return &cmd.statement.Namespace
 }

--- a/query_aggregate_command.go
+++ b/query_aggregate_command.go
@@ -63,6 +63,12 @@ func (cmd *queryAggregateCommand) parseRecordResults(ifc command, receiveSize in
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
 
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		if resultCode != 0 {
 			if resultCode == types.KEY_NOT_FOUND_ERROR {
 				// consume the rest of the input buffer from the socket
@@ -152,4 +158,11 @@ func (cmd *queryAggregateCommand) parseRecordResults(ifc command, receiveSize in
 	}
 
 	return true, nil
+}
+
+func (cmd *queryAggregateCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.statement.Namespace]++
+
+	return &response
 }

--- a/query_command.go
+++ b/query_command.go
@@ -14,6 +14,8 @@
 
 package aerospike
 
+import "iter"
+
 type queryCommand struct {
 	baseMultiCommand
 
@@ -61,7 +63,7 @@ func (cmd *queryCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryCommand) getNamespaces() map[string]uint64 {
+func (cmd *queryCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/query_command.go
+++ b/query_command.go
@@ -61,7 +61,7 @@ func (cmd *queryCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryCommand) getNamespaces() *map[string]uint64 {
+func (cmd *queryCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/query_command.go
+++ b/query_command.go
@@ -60,3 +60,10 @@ func (cmd *queryCommand) Execute() Error {
 	}
 	return err
 }
+
+func (cmd *queryCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.statement.Namespace]++
+
+	return &response
+}

--- a/query_command.go
+++ b/query_command.go
@@ -61,9 +61,10 @@ func (cmd *queryCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.statement.Namespace]++
+func (cmd *queryCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *queryCommand) getNamespace() *string {
+	return &cmd.statement.Namespace
 }

--- a/query_partition_command.go
+++ b/query_partition_command.go
@@ -67,9 +67,10 @@ func (cmd *queryPartitionCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryPartitionCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.statement.Namespace]++
+func (cmd *queryPartitionCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *queryPartitionCommand) getNamespace() *string {
+	return &cmd.statement.Namespace
 }

--- a/query_partition_command.go
+++ b/query_partition_command.go
@@ -67,7 +67,7 @@ func (cmd *queryPartitionCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryPartitionCommand) getNamespaces() *map[string]uint64 {
+func (cmd *queryPartitionCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/query_partition_command.go
+++ b/query_partition_command.go
@@ -14,6 +14,8 @@
 
 package aerospike
 
+import "iter"
+
 type queryPartitionCommand queryCommand
 
 func newQueryPartitionCommand(
@@ -67,7 +69,7 @@ func (cmd *queryPartitionCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryPartitionCommand) getNamespaces() map[string]uint64 {
+func (cmd *queryPartitionCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/query_partition_command.go
+++ b/query_partition_command.go
@@ -66,3 +66,10 @@ func (cmd *queryPartitionCommand) Execute() Error {
 	}
 	return err
 }
+
+func (cmd *queryPartitionCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.statement.Namespace]++
+
+	return &response
+}

--- a/query_partitiopn_objects_command.go
+++ b/query_partitiopn_objects_command.go
@@ -14,6 +14,8 @@
 
 package aerospike
 
+import "iter"
+
 type queryPartitionObjectsCommand queryCommand
 
 func newQueryPartitionObjectsCommand(
@@ -66,7 +68,7 @@ func (cmd *queryPartitionObjectsCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryPartitionObjectsCommand) getNamespaces() map[string]uint64 {
+func (cmd *queryPartitionObjectsCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/query_partitiopn_objects_command.go
+++ b/query_partitiopn_objects_command.go
@@ -66,9 +66,10 @@ func (cmd *queryPartitionObjectsCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryPartitionObjectsCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.statement.Namespace]++
+func (cmd *queryPartitionObjectsCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *queryPartitionObjectsCommand) getNamespace() *string {
+	return &cmd.statement.Namespace
 }

--- a/query_partitiopn_objects_command.go
+++ b/query_partitiopn_objects_command.go
@@ -65,3 +65,10 @@ func (cmd *queryPartitionObjectsCommand) Execute() Error {
 	}
 	return err
 }
+
+func (cmd *queryPartitionObjectsCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.statement.Namespace]++
+
+	return &response
+}

--- a/query_partitiopn_objects_command.go
+++ b/query_partitiopn_objects_command.go
@@ -66,7 +66,7 @@ func (cmd *queryPartitionObjectsCommand) Execute() Error {
 	return err
 }
 
-func (cmd *queryPartitionObjectsCommand) getNamespaces() *map[string]uint64 {
+func (cmd *queryPartitionObjectsCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/read_command.go
+++ b/read_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -97,7 +99,7 @@ func (cmd *readCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *readCommand) getNamespaces() map[string]uint64 {
+func (cmd *readCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/read_command.go
+++ b/read_command.go
@@ -56,6 +56,12 @@ func (cmd *readCommand) parseResult(ifc command, conn *Connection) Error {
 		return err
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	if rp.resultCode != 0 {
 		if rp.resultCode == types.KEY_NOT_FOUND_ERROR {
 			return ErrKeyNotFound.err()
@@ -89,4 +95,11 @@ func (cmd *readCommand) parseResult(ifc command, conn *Connection) Error {
 
 func (cmd *readCommand) Execute() Error {
 	return cmd.execute(cmd)
+}
+
+func (cmd *readCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace] = 1
+
+	return &response
 }

--- a/read_command.go
+++ b/read_command.go
@@ -97,9 +97,10 @@ func (cmd *readCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *readCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace] = 1
+func (cmd *readCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *readCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/read_command.go
+++ b/read_command.go
@@ -97,7 +97,7 @@ func (cmd *readCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *readCommand) getNamespaces() *map[string]uint64 {
+func (cmd *readCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/read_header_command.go
+++ b/read_header_command.go
@@ -82,7 +82,7 @@ func (cmd *readHeaderCommand) commandType() commandType {
 	return ttGetHeader
 }
 
-func (cmd *readHeaderCommand) getNamespaces() *map[string]uint64 {
+func (cmd *readHeaderCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/read_header_command.go
+++ b/read_header_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -82,7 +84,7 @@ func (cmd *readHeaderCommand) commandType() commandType {
 	return ttGetHeader
 }
 
-func (cmd *readHeaderCommand) getNamespaces() map[string]uint64 {
+func (cmd *readHeaderCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/read_header_command.go
+++ b/read_header_command.go
@@ -82,9 +82,10 @@ func (cmd *readHeaderCommand) commandType() commandType {
 	return ttGetHeader
 }
 
-func (cmd *readHeaderCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *readHeaderCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *readHeaderCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/read_header_command.go
+++ b/read_header_command.go
@@ -49,6 +49,12 @@ func (cmd *readHeaderCommand) parseResult(ifc command, conn *Connection) Error {
 		return err
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	if rp.resultCode == 0 {
 		cmd.record = newRecord(cmd.node, cmd.key, nil, rp.generation, rp.expiration)
 	} else {
@@ -74,4 +80,11 @@ func (cmd *readHeaderCommand) Execute() Error {
 
 func (cmd *readHeaderCommand) commandType() commandType {
 	return ttGetHeader
+}
+
+func (cmd *readHeaderCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/record_parser.go
+++ b/record_parser.go
@@ -29,7 +29,6 @@ type recordParser struct {
 	expiration  uint32
 	fieldCount  int
 	opCount     int
-	receiveSize int
 
 	cmd *baseCommand
 }
@@ -90,7 +89,6 @@ func newRecordParser(cmd *baseCommand) (*recordParser, Error) {
 	rp.cmd.dataOffset += 2
 	rp.opCount = int(Buffer.BytesToUint16(rp.cmd.dataBuffer, rp.cmd.dataOffset))
 	rp.cmd.dataOffset += 2
-	rp.receiveSize = int(receiveSize)
 
 	return rp, nil
 }

--- a/record_parser.go
+++ b/record_parser.go
@@ -24,11 +24,12 @@ import (
 
 // Task interface defines methods for asynchronous tasks.
 type recordParser struct {
-	resultCode types.ResultCode
-	generation uint32
-	expiration uint32
-	fieldCount int
-	opCount    int
+	resultCode  types.ResultCode
+	generation  uint32
+	expiration  uint32
+	fieldCount  int
+	opCount     int
+	receiveSize int
 
 	cmd *baseCommand
 }
@@ -89,6 +90,7 @@ func newRecordParser(cmd *baseCommand) (*recordParser, Error) {
 	rp.cmd.dataOffset += 2
 	rp.opCount = int(Buffer.BytesToUint16(rp.cmd.dataBuffer, rp.cmd.dataOffset))
 	rp.cmd.dataOffset += 2
+	rp.receiveSize = int(receiveSize)
 
 	return rp, nil
 }

--- a/scan_partition_command.go
+++ b/scan_partition_command.go
@@ -14,7 +14,11 @@
 
 package aerospike
 
-import "github.com/aerospike/aerospike-client-go/v8/types"
+import (
+	"iter"
+
+	"github.com/aerospike/aerospike-client-go/v8/types"
+)
 
 type scanPartitionCommand struct {
 	baseMultiCommand
@@ -78,7 +82,7 @@ func (cmd *scanPartitionCommand) Execute() Error {
 	return err
 }
 
-func (cmd *scanPartitionCommand) getNamespaces() map[string]uint64 {
+func (cmd *scanPartitionCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/scan_partition_command.go
+++ b/scan_partition_command.go
@@ -78,9 +78,10 @@ func (cmd *scanPartitionCommand) Execute() Error {
 	return err
 }
 
-func (cmd *scanPartitionCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.namespace]++
+func (cmd *scanPartitionCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *scanPartitionCommand) getNamespace() *string {
+	return &cmd.namespace
 }

--- a/scan_partition_command.go
+++ b/scan_partition_command.go
@@ -78,7 +78,7 @@ func (cmd *scanPartitionCommand) Execute() Error {
 	return err
 }
 
-func (cmd *scanPartitionCommand) getNamespaces() *map[string]uint64 {
+func (cmd *scanPartitionCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/scan_partition_command.go
+++ b/scan_partition_command.go
@@ -77,3 +77,10 @@ func (cmd *scanPartitionCommand) Execute() Error {
 	}
 	return err
 }
+
+func (cmd *scanPartitionCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.namespace]++
+
+	return &response
+}

--- a/scan_partition_objects_command.go
+++ b/scan_partition_objects_command.go
@@ -82,9 +82,10 @@ func (cmd *scanPartitionObjectsCommand) Execute() Error {
 	return err
 }
 
-func (cmd *scanPartitionObjectsCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.namespace]++
+func (cmd *scanPartitionObjectsCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *scanPartitionObjectsCommand) getNamespace() *string {
+	return &cmd.namespace
 }

--- a/scan_partition_objects_command.go
+++ b/scan_partition_objects_command.go
@@ -14,7 +14,11 @@
 
 package aerospike
 
-import "github.com/aerospike/aerospike-client-go/v8/types"
+import (
+	"iter"
+
+	"github.com/aerospike/aerospike-client-go/v8/types"
+)
 
 type scanPartitionObjectsCommand struct {
 	baseMultiCommand
@@ -82,7 +86,7 @@ func (cmd *scanPartitionObjectsCommand) Execute() Error {
 	return err
 }
 
-func (cmd *scanPartitionObjectsCommand) getNamespaces() map[string]uint64 {
+func (cmd *scanPartitionObjectsCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/scan_partition_objects_command.go
+++ b/scan_partition_objects_command.go
@@ -81,3 +81,10 @@ func (cmd *scanPartitionObjectsCommand) Execute() Error {
 	}
 	return err
 }
+
+func (cmd *scanPartitionObjectsCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.namespace]++
+
+	return &response
+}

--- a/scan_partition_objects_command.go
+++ b/scan_partition_objects_command.go
@@ -82,7 +82,7 @@ func (cmd *scanPartitionObjectsCommand) Execute() Error {
 	return err
 }
 
-func (cmd *scanPartitionObjectsCommand) getNamespaces() *map[string]uint64 {
+func (cmd *scanPartitionObjectsCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/server_command.go
+++ b/server_command.go
@@ -101,9 +101,10 @@ func (cmd *serverCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *serverCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.namespace]++
+func (cmd *serverCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *serverCommand) getNamespace() *string {
+	return &cmd.namespace
 }

--- a/server_command.go
+++ b/server_command.go
@@ -46,6 +46,12 @@ func (cmd *serverCommand) parseRecordResults(ifc command, receiveSize int) (bool
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
 
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		if resultCode != 0 {
 			if resultCode == types.KEY_NOT_FOUND_ERROR {
 				return false, nil
@@ -93,4 +99,11 @@ func (cmd *serverCommand) isRead() bool {
 
 func (cmd *serverCommand) Execute() Error {
 	return cmd.execute(cmd)
+}
+
+func (cmd *serverCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.namespace]++
+
+	return &response
 }

--- a/server_command.go
+++ b/server_command.go
@@ -101,7 +101,7 @@ func (cmd *serverCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *serverCommand) getNamespaces() *map[string]uint64 {
+func (cmd *serverCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/server_command.go
+++ b/server_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 	Buffer "github.com/aerospike/aerospike-client-go/v8/utils/buffer"
 )
@@ -101,7 +103,7 @@ func (cmd *serverCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *serverCommand) getNamespaces() map[string]uint64 {
+func (cmd *serverCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/single_command.go
+++ b/single_command.go
@@ -63,7 +63,7 @@ func (cmd *singleCommand) emptySocket(conn *Connection) Error {
 }
 
 
-func (cmd *singleCommand) getNamespaces() *map[string]uint64 {
+func (cmd *singleCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/single_command.go
+++ b/single_command.go
@@ -62,9 +62,11 @@ func (cmd *singleCommand) emptySocket(conn *Connection) Error {
 	return nil
 }
 
-func (cmd *singleCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
 
-	return &response
+func (cmd *singleCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
+
+func (cmd *singleCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/single_command.go
+++ b/single_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	Buffer "github.com/aerospike/aerospike-client-go/v8/utils/buffer"
 )
 
@@ -62,8 +64,7 @@ func (cmd *singleCommand) emptySocket(conn *Connection) Error {
 	return nil
 }
 
-
-func (cmd *singleCommand) getNamespaces() map[string]uint64 {
+func (cmd *singleCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/single_command.go
+++ b/single_command.go
@@ -61,3 +61,10 @@ func (cmd *singleCommand) emptySocket(conn *Connection) Error {
 	}
 	return nil
 }
+
+func (cmd *singleCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
+}

--- a/touch_command.go
+++ b/touch_command.go
@@ -48,6 +48,12 @@ func (cmd *touchCommand) parseResult(ifc command, conn *Connection) Error {
 		return newCustomNodeError(cmd.node, err.resultCode())
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, resultCode)
+	}
+
 	switch resultCode {
 	case types.OK:
 		return nil
@@ -70,4 +76,11 @@ func (cmd *touchCommand) Execute() Error {
 
 func (cmd *touchCommand) commandType() commandType {
 	return ttPut
+}
+
+func (cmd *touchCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace] = 1
+
+	return &response
 }

--- a/touch_command.go
+++ b/touch_command.go
@@ -78,9 +78,13 @@ func (cmd *touchCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *touchCommand) getNamespace() *map[string]uint64 {
+func (cmd *touchCommand) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, 1)
 	response[cmd.key.namespace] = 1
 
 	return &response
+}
+
+func (cmd *touchCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/touch_command.go
+++ b/touch_command.go
@@ -78,11 +78,11 @@ func (cmd *touchCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *touchCommand) getNamespaces() *map[string]uint64 {
+func (cmd *touchCommand) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, 1)
 	response[cmd.key.namespace] = 1
 
-	return &response
+	return response
 }
 
 func (cmd *touchCommand) getNamespace() *string {

--- a/touch_command.go
+++ b/touch_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -78,11 +80,8 @@ func (cmd *touchCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *touchCommand) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace] = 1
-
-	return response
+func (cmd *touchCommand) getNamespaces() iter.Seq2[string, uint64] {
+	return nil
 }
 
 func (cmd *touchCommand) getNamespace() *string {

--- a/txn_add_keys_command.go
+++ b/txn_add_keys_command.go
@@ -59,6 +59,12 @@ func (cmd *txnAddKeysCommand) parseResult(ifc command, conn *Connection) Error {
 	}
 	rp.parseTranDeadline(cmd.txn)
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	if rp.resultCode != types.OK {
 		return newCustomNodeError(cmd.node, rp.resultCode)
 	}
@@ -68,4 +74,11 @@ func (cmd *txnAddKeysCommand) parseResult(ifc command, conn *Connection) Error {
 
 func (cmd *txnAddKeysCommand) Execute() Error {
 	return cmd.execute(cmd)
+}
+
+func (cmd *txnAddKeysCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/txn_add_keys_command.go
+++ b/txn_add_keys_command.go
@@ -76,9 +76,10 @@ func (cmd *txnAddKeysCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *txnAddKeysCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *txnAddKeysCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *txnAddKeysCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/txn_add_keys_command.go
+++ b/txn_add_keys_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -76,7 +78,7 @@ func (cmd *txnAddKeysCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *txnAddKeysCommand) getNamespaces() map[string]uint64 {
+func (cmd *txnAddKeysCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/txn_add_keys_command.go
+++ b/txn_add_keys_command.go
@@ -76,7 +76,7 @@ func (cmd *txnAddKeysCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *txnAddKeysCommand) getNamespaces() *map[string]uint64 {
+func (cmd *txnAddKeysCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/txn_close.go
+++ b/txn_close.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -77,7 +79,7 @@ func (cmd *txnCloseCommand) onInDoubt() {
 	return
 }
 
-func (cmd *txnCloseCommand) getNamespaces() map[string]uint64 {
+func (cmd *txnCloseCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/txn_close.go
+++ b/txn_close.go
@@ -77,9 +77,10 @@ func (cmd *txnCloseCommand) onInDoubt() {
 	return
 }
 
-func (cmd *txnCloseCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *txnCloseCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *txnCloseCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/txn_close.go
+++ b/txn_close.go
@@ -77,7 +77,7 @@ func (cmd *txnCloseCommand) onInDoubt() {
 	return
 }
 
-func (cmd *txnCloseCommand) getNamespaces() *map[string]uint64 {
+func (cmd *txnCloseCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/txn_close.go
+++ b/txn_close.go
@@ -56,6 +56,12 @@ func (cmd *txnCloseCommand) parseResult(ifc command, conn *Connection) Error {
 		return newCustomNodeError(cmd.node, err.resultCode())
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, resultCode)
+	}
+
 	if resultCode == 0 || resultCode == types.KEY_NOT_FOUND_ERROR {
 		return nil
 	}
@@ -69,4 +75,11 @@ func (cmd *txnCloseCommand) Execute() Error {
 
 func (cmd *txnCloseCommand) onInDoubt() {
 	return
+}
+
+func (cmd *txnCloseCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/txn_mark_roll_forward.go
+++ b/txn_mark_roll_forward.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -69,7 +71,7 @@ func (cmd *txnMarkRollForwardCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *txnMarkRollForwardCommand) getNamespaces() map[string]uint64 {
+func (cmd *txnMarkRollForwardCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/txn_mark_roll_forward.go
+++ b/txn_mark_roll_forward.go
@@ -69,7 +69,7 @@ func (cmd *txnMarkRollForwardCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *txnMarkRollForwardCommand) getNamespaces() *map[string]uint64 {
+func (cmd *txnMarkRollForwardCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/txn_mark_roll_forward.go
+++ b/txn_mark_roll_forward.go
@@ -69,9 +69,11 @@ func (cmd *txnMarkRollForwardCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *txnMarkRollForwardCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *txnMarkRollForwardCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *txnMarkRollForwardCommand) getNamespace() *string {
+	return &cmd.key.namespace
+
 }

--- a/txn_mark_roll_forward.go
+++ b/txn_mark_roll_forward.go
@@ -52,6 +52,12 @@ func (cmd *txnMarkRollForwardCommand) parseResult(ifc command, conn *Connection)
 		return newCustomNodeError(cmd.node, err.resultCode())
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, resultCode)
+	}
+
 	if resultCode == 0 || resultCode == types.MRT_COMMITTED {
 		return nil
 	}
@@ -61,4 +67,11 @@ func (cmd *txnMarkRollForwardCommand) parseResult(ifc command, conn *Connection)
 
 func (cmd *txnMarkRollForwardCommand) Execute() Error {
 	return cmd.execute(cmd)
+}
+
+func (cmd *txnMarkRollForwardCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/txn_roll.go
+++ b/txn_roll.go
@@ -239,3 +239,4 @@ func (txr *TxnRoll) Close(writePolicy *WritePolicy, txnKey *Key) Error {
 
 	return nil
 }
+

--- a/txn_roll_batch.go
+++ b/txn_roll_batch.go
@@ -211,11 +211,15 @@ func (cmd *batchTxnRollCommand) generateBatchNodes(cluster *Cluster) ([]*batchNo
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, cmd.attr.hasWrite)
 }
 
-func (cmd *batchTxnRollCommand) getNamespace() *map[string]uint64 {
+func (cmd *batchTxnRollCommand) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.Namespace()]++
 	}
 
 	return &response
+}
+
+func (cmd *batchTxnRollCommand) getNamespace() *string {
+	return nil
 }

--- a/txn_roll_batch.go
+++ b/txn_roll_batch.go
@@ -211,13 +211,13 @@ func (cmd *batchTxnRollCommand) generateBatchNodes(cluster *Cluster) ([]*batchNo
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, cmd.attr.hasWrite)
 }
 
-func (cmd *batchTxnRollCommand) getNamespaces() *map[string]uint64 {
+func (cmd *batchTxnRollCommand) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.Namespace()]++
 	}
 
-	return &response
+	return response
 }
 
 func (cmd *batchTxnRollCommand) getNamespace() *string {

--- a/txn_roll_batch.go
+++ b/txn_roll_batch.go
@@ -15,6 +15,7 @@
 package aerospike
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/aerospike/aerospike-client-go/v8/types"
@@ -211,15 +212,18 @@ func (cmd *batchTxnRollCommand) generateBatchNodes(cluster *Cluster) ([]*batchNo
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, cmd.attr.hasWrite)
 }
 
-func (cmd *batchTxnRollCommand) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.keys))
-	for _, key := range cmd.keys {
-		response[key.Namespace()]++
-	}
-
-	return response
+func (cmd *batchTxnRollCommand) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *batchTxnRollCommand) getNamespace() *string {
 	return nil
+}
+
+func (cmd *batchTxnRollCommand) nsIter(yield func(string, uint64) bool) {
+	for _, key := range cmd.keys {
+		if !yield(key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/txn_roll_batch.go
+++ b/txn_roll_batch.go
@@ -91,6 +91,12 @@ func (cmd *batchTxnRollCommand) parseRecordResults(ifc command, receiveSize int)
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
 
+		// Aggregate metrics
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		// The only valid server return codes are "ok" and "not found" and "filtered out".
 		// If other return codes are received, then abort the batch.
 		if resultCode != 0 && resultCode != types.KEY_NOT_FOUND_ERROR {
@@ -203,4 +209,13 @@ func (cmd *batchTxnRollCommand) Execute() Error {
 
 func (cmd *batchTxnRollCommand) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, cmd.attr.hasWrite)
+}
+
+func (cmd *batchTxnRollCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.keys))
+	for _, key := range cmd.keys {
+		response[key.Namespace()]++
+	}
+
+	return &response
 }

--- a/txn_roll_batch_single.go
+++ b/txn_roll_batch_single.go
@@ -88,6 +88,12 @@ func (cmd *batchSingleTxnRollCommand) parseResult(ifc command, conn *Connection)
 		return err
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, rp.resultCode)
+	}
+
 	if rp.resultCode == 0 {
 		cmd.record.ResultCode = types.OK
 	} else {

--- a/txn_roll_batch_single.go
+++ b/txn_roll_batch_single.go
@@ -123,3 +123,4 @@ func (cmd *batchSingleTxnRollCommand) Execute() Error {
 func (cmd *batchSingleTxnRollCommand) commandType() commandType {
 	return ttPut
 }
+

--- a/txn_verify_batch.go
+++ b/txn_verify_batch.go
@@ -15,6 +15,7 @@
 package aerospike
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/aerospike/aerospike-client-go/v8/types"
@@ -192,14 +193,18 @@ func (cmd *txnBatchVerifyCommand) generateBatchNodes(cluster *Cluster) ([]*batch
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *txnBatchVerifyCommand) getNamespaces() map[string]uint64 {
-	response := make(map[string]uint64, len(cmd.keys))
-	for _, key := range cmd.keys {
-		response[key.Namespace()]++
-	}
-	return response
+func (cmd *txnBatchVerifyCommand) getNamespaces() iter.Seq2[string, uint64] {
+	return cmd.nsIter
 }
 
 func (cmd *txnBatchVerifyCommand) getNamespace() *string {
 	return nil
+}
+
+func (cmd *txnBatchVerifyCommand) nsIter(yield func(string, uint64) bool) {
+	for _, key := range cmd.keys {
+		if !yield(key.namespace, 1) {
+			return
+		}
+	}
 }

--- a/txn_verify_batch.go
+++ b/txn_verify_batch.go
@@ -192,12 +192,12 @@ func (cmd *txnBatchVerifyCommand) generateBatchNodes(cluster *Cluster) ([]*batch
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *txnBatchVerifyCommand) getNamespaces() *map[string]uint64 {
+func (cmd *txnBatchVerifyCommand) getNamespaces() map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.Namespace()]++
 	}
-	return &response
+	return response
 }
 
 func (cmd *txnBatchVerifyCommand) getNamespace() *string {

--- a/txn_verify_batch.go
+++ b/txn_verify_batch.go
@@ -88,6 +88,11 @@ func (cmd *txnBatchVerifyCommand) parseRecordResults(ifc command, receiveSize in
 		}
 		resultCode := types.ResultCode(cmd.dataBuffer[5] & 0xFF)
 
+		metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+		if metricsEnabled {
+			cmd.node.stats.updateOrInsert(ifc, resultCode)
+		}
+
 		// The only valid server return codes are "ok" and "not found" and "filtered out".
 		// If other return codes are received, then abort the batch.
 		if resultCode != 0 && resultCode != types.KEY_NOT_FOUND_ERROR {
@@ -185,4 +190,12 @@ func (cmd *txnBatchVerifyCommand) Execute() Error {
 
 func (cmd *txnBatchVerifyCommand) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
+}
+
+func (cmd *txnBatchVerifyCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, len(cmd.keys))
+	for _, key := range cmd.keys {
+		response[key.Namespace()]++
+	}
+	return &response
 }

--- a/txn_verify_batch.go
+++ b/txn_verify_batch.go
@@ -192,10 +192,14 @@ func (cmd *txnBatchVerifyCommand) generateBatchNodes(cluster *Cluster) ([]*batch
 	return newBatchNodeListKeys(cluster, cmd.policy, cmd.keys, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch, false)
 }
 
-func (cmd *txnBatchVerifyCommand) getNamespace() *map[string]uint64 {
+func (cmd *txnBatchVerifyCommand) getNamespaces() *map[string]uint64 {
 	response := make(map[string]uint64, len(cmd.keys))
 	for _, key := range cmd.keys {
 		response[key.Namespace()]++
 	}
 	return &response
+}
+
+func (cmd *txnBatchVerifyCommand) getNamespace() *string {
+	return nil
 }

--- a/txn_verify_batch_single.go
+++ b/txn_verify_batch_single.go
@@ -180,7 +180,7 @@ func (cmd *batchSingleTxnVerifyCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *batchSingleTxnVerifyCommand) getNamespaces() *map[string]uint64 {
+func (cmd *batchSingleTxnVerifyCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/txn_verify_batch_single.go
+++ b/txn_verify_batch_single.go
@@ -16,6 +16,7 @@ package aerospike
 
 import (
 	"fmt"
+	"iter"
 
 	"github.com/aerospike/aerospike-client-go/v8/logger"
 	"github.com/aerospike/aerospike-client-go/v8/types"
@@ -180,7 +181,7 @@ func (cmd *batchSingleTxnVerifyCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *batchSingleTxnVerifyCommand) getNamespaces() map[string]uint64 {
+func (cmd *batchSingleTxnVerifyCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/txn_verify_batch_single.go
+++ b/txn_verify_batch_single.go
@@ -180,9 +180,10 @@ func (cmd *batchSingleTxnVerifyCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *batchSingleTxnVerifyCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *batchSingleTxnVerifyCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *batchSingleTxnVerifyCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/txn_verify_batch_single.go
+++ b/txn_verify_batch_single.go
@@ -126,6 +126,13 @@ func (cmd *batchSingleTxnVerifyCommand) parseResult(ifc command, conn *Connectio
 
 	headerLength := int(cmd.dataBuffer[8])
 	resultCode := types.ResultCode(cmd.dataBuffer[13] & 0xFF)
+
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, resultCode)
+	}
+
 	// generation := Buffer.BytesToUint32(cmd.dataBuffer, 14)
 	// expiration := types.TTL(Buffer.BytesToUint32(cmd.dataBuffer, 18))
 	// fieldCount := int(Buffer.BytesToUint16(cmd.dataBuffer, 26)) // almost certainly 0
@@ -171,4 +178,11 @@ func (cmd *batchSingleTxnVerifyCommand) Execute() Error {
 
 func (cmd *batchSingleTxnVerifyCommand) commandType() commandType {
 	return ttPut
+}
+
+func (cmd *batchSingleTxnVerifyCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/types/histogram/sync_histogram.go
+++ b/types/histogram/sync_histogram.go
@@ -138,6 +138,7 @@ func (h *SyncHistogram[T]) CloneAndReset() *SyncHistogram[T] {
 
 func (h *SyncHistogram[T]) Merge(other *SyncHistogram[T]) error {
 	h.l.Lock()
+	other.l.RLock()
 
 	// It is possible to try to get lock on the same histogram in the same goroutine
 	// Making sure we don't deadlock
@@ -147,7 +148,7 @@ func (h *SyncHistogram[T]) Merge(other *SyncHistogram[T]) error {
 
 	if h.base != other.base || h.htype != other.htype || len(h.Buckets) != len(other.Buckets) {
 		h.l.Unlock()
-		return errors.New("Histograms to not match")
+		return errors.New("histograms do not match")
 	}
 
 	if other.Min < h.Min || h.Min == 0 {
@@ -164,6 +165,7 @@ func (h *SyncHistogram[T]) Merge(other *SyncHistogram[T]) error {
 	for i := range h.Buckets {
 		h.Buckets[i] += other.Buckets[i]
 	}
+	other.l.RUnlock()
 	h.l.Unlock()
 	return nil
 }

--- a/types/histogram/sync_histogram.go
+++ b/types/histogram/sync_histogram.go
@@ -140,13 +140,8 @@ func (h *SyncHistogram[T]) Merge(other *SyncHistogram[T]) error {
 	h.l.Lock()
 	other.l.RLock()
 
-	// It is possible to try to get lock on the same histogram in the same goroutine
-	// Making sure we don't deadlock
-	if locked := other.l.TryRLock(); locked {
-		defer other.l.RUnlock()
-	}
-
 	if h.base != other.base || h.htype != other.htype || len(h.Buckets) != len(other.Buckets) {
+		other.l.RUnlock()
 		h.l.Unlock()
 		return errors.New("histograms do not match")
 	}

--- a/types/histogram/sync_histogram.go
+++ b/types/histogram/sync_histogram.go
@@ -138,9 +138,14 @@ func (h *SyncHistogram[T]) CloneAndReset() *SyncHistogram[T] {
 
 func (h *SyncHistogram[T]) Merge(other *SyncHistogram[T]) error {
 	h.l.Lock()
-	other.l.RLock()
+
+	// It is possible to try to get lock on the same histogram in the same goroutine
+	// Making sure we don't deadlock
+	if locked := other.l.TryRLock(); locked {
+		defer other.l.RUnlock()
+	}
+
 	if h.base != other.base || h.htype != other.htype || len(h.Buckets) != len(other.Buckets) {
-		other.l.RUnlock()
 		h.l.Unlock()
 		return errors.New("Histograms to not match")
 	}
@@ -159,9 +164,7 @@ func (h *SyncHistogram[T]) Merge(other *SyncHistogram[T]) error {
 	for i := range h.Buckets {
 		h.Buckets[i] += other.Buckets[i]
 	}
-	other.l.RUnlock()
 	h.l.Unlock()
-
 	return nil
 }
 

--- a/write_command.go
+++ b/write_command.go
@@ -15,6 +15,8 @@
 package aerospike
 
 import (
+	"iter"
+
 	"github.com/aerospike/aerospike-client-go/v8/types"
 )
 
@@ -85,7 +87,7 @@ func (cmd *writeCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *writeCommand) getNamespaces() map[string]uint64 {
+func (cmd *writeCommand) getNamespaces() iter.Seq2[string, uint64] {
 	return nil
 }
 

--- a/write_command.go
+++ b/write_command.go
@@ -85,7 +85,7 @@ func (cmd *writeCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *writeCommand) getNamespaces() *map[string]uint64 {
+func (cmd *writeCommand) getNamespaces() map[string]uint64 {
 	return nil
 }
 

--- a/write_command.go
+++ b/write_command.go
@@ -85,9 +85,10 @@ func (cmd *writeCommand) Execute() Error {
 	return cmd.execute(cmd)
 }
 
-func (cmd *writeCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
-	
-	return &response
+func (cmd *writeCommand) getNamespaces() *map[string]uint64 {
+	return nil
+}
+
+func (cmd *writeCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }

--- a/write_command.go
+++ b/write_command.go
@@ -62,6 +62,12 @@ func (cmd *writeCommand) parseResult(ifc command, conn *Connection) Error {
 		return newCustomNodeError(cmd.node, err.resultCode())
 	}
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, resultCode)
+	}
+
 	if resultCode != types.OK {
 		if resultCode == types.KEY_NOT_FOUND_ERROR {
 			return ErrKeyNotFound.err()
@@ -77,4 +83,11 @@ func (cmd *writeCommand) parseResult(ifc command, conn *Connection) Error {
 
 func (cmd *writeCommand) Execute() Error {
 	return cmd.execute(cmd)
+}
+
+func (cmd *writeCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+	
+	return &response
 }

--- a/write_payload_command.go
+++ b/write_payload_command.go
@@ -91,6 +91,12 @@ func (cmd *writePayloadCommand) parseResult(ifc command, conn *Connection) Error
 
 	resultCode := cmd.dataBuffer[13] & 0xFF
 
+	// Aggregate metrics
+	metricsEnabled := cmd.node.cluster.metricsEnabled.Load()
+	if metricsEnabled {
+		cmd.node.stats.updateOrInsert(ifc, types.ResultCode(resultCode))
+	}
+
 	if resultCode != 0 {
 		if resultCode == byte(types.KEY_NOT_FOUND_ERROR) {
 			return ErrKeyNotFound.err()
@@ -113,4 +119,11 @@ func (cmd *writePayloadCommand) Execute() Error {
 
 func (cmd *writePayloadCommand) commandType() commandType {
 	return ttPut
+}
+
+func (cmd *writePayloadCommand) getNamespace() *map[string]uint64 {
+	response := make(map[string]uint64, 1)
+	response[cmd.key.namespace]++
+
+	return &response
 }

--- a/write_payload_command.go
+++ b/write_payload_command.go
@@ -121,9 +121,10 @@ func (cmd *writePayloadCommand) commandType() commandType {
 	return ttPut
 }
 
-func (cmd *writePayloadCommand) getNamespace() *map[string]uint64 {
-	response := make(map[string]uint64, 1)
-	response[cmd.key.namespace]++
+func (cmd *writePayloadCommand) getnamespaces() *map[string]uint64 {
+	return nil
+}
 
-	return &response
+func (cmd *writePayloadCommand) getNamespace() *string {
+	return &cmd.key.namespace
 }


### PR DESCRIPTION
Adding detailed metrics and resultcodes with namespaces to golang client.

- [x] Added latency for node/namespace/ and cluster 
- [x] Added bytes-sent bytes-received for node/namespace/command and cluster 
- [x] Added connection acquired for node/namespace/command and cluster 
- [x] Added parsing latency for node/namespace/command and cluster 
- [x] Added all (0 - 255) server error counts for node/namespace/command and cluster 
- [x] Added labels for the cluster

Valided and optimized updateOrInsert calls. Below is a list of benchmarks as result of those optimizations.

```go
	_, err = func() (int, Error) {
		if metricsEnabled {
			var dataSent = 0
			start := time.Now()
			dataSent, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
			cmd.applyDetailedMetricsBytesSentAndTransmission(ifc, dataSent, start)
			return dataSent, err
		}
		return cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
	}()
```

=== RUN   BenchmarkApplyDetailedMetricsBytesSentAndTransmission
BenchmarkApplyDetailedMetricsBytesSentAndTransmission
BenchmarkApplyDetailedMetricsBytesSentAndTransmission-14         8375888               131.0 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkApplyDetailedConnectionAq
BenchmarkApplyDetailedConnectionAq
BenchmarkApplyDetailedConnectionAq-14                           11469990               103.1 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkApplyDetailedParsing
BenchmarkApplyDetailedParsing
BenchmarkApplyDetailedParsing-14                                11457337               104.4 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkCommandMergeCommandResultCodeMetrics
BenchmarkCommandMergeCommandResultCodeMetrics
BenchmarkCommandMergeCommandResultCodeMetrics-14                 3045164               401.4 ns/op            64 B/op          5 allocs/op
=== RUN   BenchmarkCommandMergeDetailMetrics
BenchmarkCommandMergeDetailMetrics
BenchmarkCommandMergeDetailMetrics-14                            5773930               202.5 ns/op            24 B/op          2 allocs/op
=== RUN   BenchmarkConnectionAcWithMetrics
BenchmarkConnectionAcWithMetrics
BenchmarkConnectionAcWithMetrics-14                             10457097               115.9 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkParseAcWithMetrics
BenchmarkParseAcWithMetrics
BenchmarkParseAcWithMetrics-14                                  10541271               114.7 ns/op            24 B/op          1 allocs/op
PASS


Benchmark results without  inline optimizations, aka  on metrics callection in the command.executeAt method. As example
 
```go
	if metricsEnabled {
		start := time.Now()
		dataSent, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
		cmd.applyDetailedMetricsBytesSentAndTransmission(ifc, dataSent, start)
	} else {
		_, err = cmd.conn.Write(cmd.dataBuffer[:cmd.dataOffset])
	}
```

=== RUN   BenchmarkApplyDetailedMetricsBytesSentAndTransmission
BenchmarkApplyDetailedMetricsBytesSentAndTransmission
BenchmarkApplyDetailedMetricsBytesSentAndTransmission-14         8488948               132.0 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkApplyDetailedConnectionAq
BenchmarkApplyDetailedConnectionAq
BenchmarkApplyDetailedConnectionAq-14                           11312936               107.7 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkApplyDetailedParsing
BenchmarkApplyDetailedParsing
BenchmarkApplyDetailedParsing-14                                10988397               108.8 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkCommandMergeCommandResultCodeMetrics
BenchmarkCommandMergeCommandResultCodeMetrics
BenchmarkCommandMergeCommandResultCodeMetrics-14                 2924882               412.2 ns/op            64 B/op          5 allocs/op
=== RUN   BenchmarkCommandMergeDetailMetrics
BenchmarkCommandMergeDetailMetrics
BenchmarkCommandMergeDetailMetrics-14                            5800849               207.9 ns/op            24 B/op          2 allocs/op


------------> benchmarks without inline optmizations

=== RUN   BenchmarkConnectionAcWithMetrics
BenchmarkConnectionAcWithMetrics
BenchmarkConnectionAcWithMetrics-14                              9772182               120.3 ns/op            24 B/op          1 allocs/op
=== RUN   BenchmarkParseAcWithMetrics
BenchmarkParseAcWithMetrics
BenchmarkParseAcWithMetrics-14                                  10514532               115.9 ns/op            24 B/op          1 allocs/op
PASS
ok      github.com/aerospike/aerospike-client-go/v8     9.834s


Filtered result snipped of Stats() snapshot:

```json
{
  "127.0.0.1:3100": {
    "batch-read-metrics": {
      "buckets": [
        0,
        0,
        0,
        3
      ],
      "count": 3,
      "max": 538,
      "min": 451,
      "sum": 1494
    },
    "batch-write-metrics": {
      "buckets": [
        0,
        0,
        0,
        1
      ],
      "count": 1,
      "max": 502,
      "min": 502,
      "sum": 502
    },
    "circuit-breaker-hits": 0,
    "closed-connections": 0,
    "connections-attempts": 100,
    "connections-error-other": 0,
    "connections-error-timeout": 0,
    "connections-failed": 0,
    "connections-idle-dropped": 0,
    "connections-pool-empty": 0,
    "connections-pool-overflow": 0,
    "connections-successful": 100,
    "delete-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "detailed-metrics": {
      "test": {
        "BatchRead": {
          "bytes-received": {
            "buckets": [
              0,
              0,
              0,
              3
            ],
            "count": 3,
            "max": 430,
            "min": 214,
            "sum": 858
          },
          "bytes-sent": {
            "buckets": [
              0,
              0,
              0,
              3
            ],
            "count": 3,
            "max": 285,
            "min": 269,
            "sum": 823
          },
          "connection-aq": {
            "buckets": [
              2,
              0,
              0,
              1
            ],
            "count": 3,
            "max": 9,
            "min": 0,
            "sum": 9
          },
          "latency": {
            "buckets": [
              0,
              0,
              1,
              2
            ],
            "count": 3,
            "max": 10,
            "min": 5,
            "sum": 23
          },
          "parsing": {
            "buckets": [
              0,
              0,
              0,
              3
            ],
            "count": 3,
            "max": 511,
            "min": 438,
            "sum": 1444
          }
        },
        "BatchWrite": {
          "bytes-received": {
            "buckets": [
              0,
              0,
              0,
              1
            ],
            "count": 1,
            "max": 214,
            "min": 214,
            "sum": 214
          },
          "bytes-sent": {
            "buckets": [
              0,
              0,
              0,
              1
            ],
            "count": 1,
            "max": 271,
            "min": 271,
            "sum": 271
          },
          "connection-aq": {
            "buckets": [
              1,
              0,
              0,
              0
            ],
            "count": 1,
            "max": 0,
            "min": 0,
            "sum": 0
          },
          "latency": {
            "buckets": [
              0,
              0,
              1,
              0
            ],
            "count": 1,
            "max": 6,
            "min": 6,
            "sum": 6
          },
          "parsing": {
            "buckets": [
              0,
              0,
              0,
              1
            ],
            "count": 1,
            "max": 491,
            "min": 491,
            "sum": 491
          }
        },
        "Put": {
          "bytes-received": {
            "buckets": [
              0,
              0,
              0,
              8
            ],
            "count": 8,
            "max": 30,
            "min": 30,
            "sum": 240
          },
          "bytes-sent": {
            "buckets": [
              0,
              0,
              0,
              8
            ],
            "count": 8,
            "max": 100,
            "min": 100,
            "sum": 800
          },
          "connection-aq": {
            "buckets": [
              8,
              0,
              0,
              0
            ],
            "count": 8,
            "max": 1,
            "min": 0,
            "sum": 1
          },
          "latency": {
            "buckets": [
              0,
              0,
              3,
              5
            ],
            "count": 8,
            "max": 15,
            "min": 5,
            "sum": 64
          },
          "parsing": {
            "buckets": [
              0,
              0,
              0,
              8
            ],
            "count": 8,
            "max": 1263,
            "min": 291,
            "sum": 3575
          }
        }
      }
    },
    "detailed-resultcode-counts": {
      "test": {
        "BatchRead": {
          "OK": 24
        },
        "BatchWrite": {
          "OK": 8
        },
        "Put": {
          "OK": 8
        }
      }
    },
    "exists-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "get-header-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "get-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "node-added-count": 1,
    "node-removed-count": 0,
    "open-connections": 100,
    "operate-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "partition-map-updates": 1,
    "put-metrics": {
      "buckets": [
        0,
        0,
        0,
        8
      ],
      "count": 8,
      "max": 1358,
      "min": 302,
      "sum": 3743
    },
    "query-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "scan-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "tends-failed": 0,
    "tends-successful": 2,
    "tends-total": 2,
    "transaction-error-count": 0,
    "transaction-retry-count": 0,
    "udf-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    }
  },
  "cluster-aggregated-stats": {
    "batch-read-metrics": {
      "buckets": [
        0,
        0,
        0,
        3
      ],
      "count": 3,
      "max": 538,
      "min": 451,
      "sum": 1494
    },
    "batch-write-metrics": {
      "buckets": [
        0,
        0,
        0,
        1
      ],
      "count": 1,
      "max": 502,
      "min": 502,
      "sum": 502
    },
    "circuit-breaker-hits": 0,
    "closed-connections": 0,
    "connections-attempts": 100,
    "connections-error-other": 0,
    "connections-error-timeout": 0,
    "connections-failed": 0,
    "connections-idle-dropped": 0,
    "connections-pool-empty": 0,
    "connections-pool-overflow": 0,
    "connections-successful": 100,
    "delete-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "detailed-metrics": {
      "test": {
        "BatchRead": {
          "bytes-received": {
            "buckets": [
              0,
              0,
              0,
              3
            ],
            "count": 3,
            "max": 430,
            "min": 214,
            "sum": 858
          },
          "bytes-sent": {
            "buckets": [
              0,
              0,
              0,
              3
            ],
            "count": 3,
            "max": 285,
            "min": 269,
            "sum": 823
          },
          "connection-aq": {
            "buckets": [
              2,
              0,
              0,
              1
            ],
            "count": 3,
            "max": 9,
            "min": 0,
            "sum": 9
          },
          "latency": {
            "buckets": [
              0,
              0,
              1,
              2
            ],
            "count": 3,
            "max": 10,
            "min": 5,
            "sum": 23
          },
          "parsing": {
            "buckets": [
              0,
              0,
              0,
              3
            ],
            "count": 3,
            "max": 511,
            "min": 438,
            "sum": 1444
          }
        },
        "BatchWrite": {
          "bytes-received": {
            "buckets": [
              0,
              0,
              0,
              1
            ],
            "count": 1,
            "max": 214,
            "min": 214,
            "sum": 214
          },
          "bytes-sent": {
            "buckets": [
              0,
              0,
              0,
              1
            ],
            "count": 1,
            "max": 271,
            "min": 271,
            "sum": 271
          },
          "connection-aq": {
            "buckets": [
              1,
              0,
              0,
              0
            ],
            "count": 1,
            "max": 0,
            "min": 0,
            "sum": 0
          },
          "latency": {
            "buckets": [
              0,
              0,
              1,
              0
            ],
            "count": 1,
            "max": 6,
            "min": 6,
            "sum": 6
          },
          "parsing": {
            "buckets": [
              0,
              0,
              0,
              1
            ],
            "count": 1,
            "max": 491,
            "min": 491,
            "sum": 491
          }
        },
        "Put": {
          "bytes-received": {
            "buckets": [
              0,
              0,
              0,
              8
            ],
            "count": 8,
            "max": 30,
            "min": 30,
            "sum": 240
          },
          "bytes-sent": {
            "buckets": [
              0,
              0,
              0,
              8
            ],
            "count": 8,
            "max": 100,
            "min": 100,
            "sum": 800
          },
          "connection-aq": {
            "buckets": [
              8,
              0,
              0,
              0
            ],
            "count": 8,
            "max": 1,
            "min": 0,
            "sum": 1
          },
          "latency": {
            "buckets": [
              0,
              0,
              3,
              5
            ],
            "count": 8,
            "max": 15,
            "min": 5,
            "sum": 64
          },
          "parsing": {
            "buckets": [
              0,
              0,
              0,
              8
            ],
            "count": 8,
            "max": 1263,
            "min": 291,
            "sum": 3575
          }
        }
      }
    },
    "detailed-resultcode-counts": {
      "test": {
        "BatchRead": {
          "OK": 24
        },
        "BatchWrite": {
          "OK": 8
        },
        "Put": {
          "OK": 8
        }
      }
    },
    "exceeded-max-retries": 0,
    "exceeded-total-timeout": 0,
    "exists-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "get-header-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "get-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "labels": [
      {
        "app-id": "",
        "cluster": "",
        "host": "127.0.0.1:3100",
        "node": "BB979E256BB9B1A"
      }
    ],
    "node-added-count": 1,
    "node-removed-count": 0,
    "open-connections": 100,
    "operate-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "partition-map-updates": 1,
    "put-metrics": {
      "buckets": [
        0,
        0,
        0,
        8
      ],
      "count": 8,
      "max": 1358,
      "min": 302,
      "sum": 3743
    },
    "query-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "scan-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    },
    "tends-failed": 0,
    "tends-successful": 2,
    "tends-total": 2,
    "transaction-error-count": 0,
    "transaction-retry-count": 0,
    "udf-metrics": {
      "buckets": [
        0,
        0,
        0,
        0
      ],
      "count": 0,
      "max": 0,
      "min": 0,
      "sum": 0
    }
  },
  "open-connections": 100,
  "total-nodes": 1
}
```