### PR TITLE
Go Client v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change History
 
+## March 18 2025: v8.2.0
+
+- **Fixes**
+  - [CLIENT-3379] Setting `TotalTimeout` to 0 causes Scan / Query to fail (timeout).
+  - [CLIENT-3376] `BatchRead` on Non-Existing namespace with transaction policy does not throw expected error.
+  - [CLIENT-3353] Insufficient Error Messages from MRT commit failure.
+  - [CLIENT-3374] Fix panic when trying to commit a MRT with no read and write transaction.
+
+- **Improvements**
+  - [CLIENT-3361] Update documentation for `RecordsPerSecond` scan/query policy.
+
 ## February 26 2025: v8.1.0
 
 - **New Features**

--- a/admin_command.go
+++ b/admin_command.go
@@ -396,7 +396,7 @@ func (acmd *AdminCommand) executeCommand(conn *Connection, policy *AdminPolicy) 
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := conn.SetTimeout(timeout, timeout); err != nil {
 		return err
 	}
 
@@ -426,7 +426,7 @@ func (acmd *AdminCommand) readUsers(conn *Connection, policy *AdminPolicy) ([]*U
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := conn.SetTimeout(timeout, timeout); err != nil {
 		return nil, err
 	}
 
@@ -579,7 +579,7 @@ func (acmd *AdminCommand) readRoles(conn *Connection, policy *AdminPolicy) ([]*R
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := conn.SetTimeout(timeout, timeout); err != nil {
 		return nil, err
 	}
 

--- a/aerospike_suite_test.go
+++ b/aerospike_suite_test.go
@@ -59,6 +59,7 @@ var (
 	tlsConfig    *tls.Config
 	clientPolicy *as.ClientPolicy
 	client       *as.Client
+	dbHosts      []*as.Host
 )
 
 func initTestVars() {
@@ -93,8 +94,6 @@ func initTestVars() {
 	tlsConfig = initTLS()
 	clientPolicy.TlsConfig = tlsConfig
 	clientPolicy.UseServicesAlternate = *UseServicesAlternate
-
-	var dbHosts []*as.Host
 
 	if len(strings.TrimSpace(*hosts)) > 0 {
 		dbHosts, err = as.NewHosts(strings.Split(*hosts, ",")...)

--- a/batch_command.go
+++ b/batch_command.go
@@ -14,17 +14,13 @@
 
 package aerospike
 
-import (
-	"time"
-)
-
 type batcher interface {
 	command
 
 	cloneBatchCommand(batch *batchNode) batcher
 	filteredOut() int
 
-	retryBatch(ifc batcher, cluster *Cluster, deadline time.Time, iteration int) (bool, Error)
+	retryBatch(ifc batcher, cluster *Cluster, iteration int) (bool, Error)
 	generateBatchNodes(*Cluster) ([]*batchNode, Error)
 	setSequence(int, int)
 
@@ -75,7 +71,7 @@ func (cmd *batchCommand) prepareRetry(ifc command, isTimeout bool) bool {
 	return false
 }
 
-func (cmd *batchCommand) retryBatch(ifc batcher, cluster *Cluster, deadline time.Time, iteration int) (bool, Error) {
+func (cmd *batchCommand) retryBatch(ifc batcher, cluster *Cluster, iteration int) (bool, Error) {
 	// Retry requires keys for this node to be split among other nodes.
 	// This is both recursive and exponential.
 	batchNodes, err := ifc.generateBatchNodes(cluster)

--- a/batch_test.go
+++ b/batch_test.go
@@ -427,6 +427,21 @@ var _ = gg.Describe("Aerospike", func() {
 				// gm.Expect(err.Matches(types.BATCH_MAX_REQUESTS_EXCEEDED)).To(gm.BeTrue())
 			})
 
+			gg.It("XXXShould return the error for invalid namespace", func() {
+				var brs []as.BatchRecordIfc
+
+				for i := 0; i < 1; i++ {
+					key, _ := as.NewKey("non_exist", "non_exist", i)
+					brr := as.NewBatchReadOps(nil, key, []*as.Operation{as.GetBinOp("i_bin")}...)
+					brs = append(brs, brr)
+				}
+
+				bp := as.NewBatchPolicy()
+				err := client.BatchOperate(bp, brs)
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.INVALID_NAMESPACE)).To(gm.BeTrue())
+			})
+
 			gg.It("Overall command error should be reflected in API call error and not BatchRecord error", func() {
 				var batchRecords []as.BatchRecordIfc
 				key, _ := as.NewKey(*namespace, set, 0)

--- a/client.go
+++ b/client.go
@@ -858,6 +858,10 @@ func (clnt *Client) BatchOperate(policy *BatchPolicy, records []BatchRecordIfc) 
 		return err
 	}
 
+	if len(batchNodes) == 0 {
+		return newError(types.INVALID_NAMESPACE)
+	}
+
 	cmd := newBatchCommandOperate(clnt, nil, policy, records)
 	_, err = clnt.batchExecute(policy, batchNodes, &cmd)
 	return err

--- a/command.go
+++ b/command.go
@@ -3647,7 +3647,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 			if !ifc.prepareRetry(ifc, isClientTimeout || (err != nil && err.Matches(types.SERVER_NOT_AVAILABLE))) {
 				if bc, ok := ifc.(batcher); ok {
 					// Batch may be retried in separate commands.
-					alreadyRetried, err := bc.retryBatch(bc, cmd.node.cluster, deadline, cmd.commandSentCounter)
+					alreadyRetried, err := bc.retryBatch(bc, cmd.node.cluster, cmd.commandSentCounter)
 					if alreadyRetried {
 						// Batch was retried in separate subcommands. Complete this command.
 						applyTransactionMetrics(cmd.node, ifc.commandType(), transStart)

--- a/connection.go
+++ b/connection.go
@@ -63,8 +63,9 @@ type Connection struct {
 	node *Node
 
 	// timeouts
-	socketTimeout time.Duration
-	deadline      time.Time
+	socketTimeout  time.Duration
+	deadline       time.Time
+	socketDeadline time.Time // this is not strictly required, but is used in testing
 
 	// duration after which connection is considered idle
 	idleTimeout  time.Duration
@@ -155,7 +156,7 @@ func newConnection(address string, timeout time.Duration) (*Connection, Error) {
 	newConn.limitReader = &io.LimitedReader{R: conn, N: 0}
 
 	// set timeout at the last possible moment
-	if err := newConn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := newConn.SetTimeout(timeout, timeout); err != nil {
 		newConn.Close()
 		return nil, err
 	}
@@ -262,6 +263,14 @@ func (ctn *Connection) Read(buf []byte, length int) (total int, aerr Error) {
 		}
 		total += r
 		if err != nil {
+			time.Sleep(time.Millisecond)
+			if netErr, ok := err.(net.Error); ok {
+				if netErr.Timeout() && r > 0 {
+					// We had a timeout, but we also read some data;
+					// Continue to read as long as the totalDeadline is not reached
+					continue
+				}
+			}
 			break
 		}
 	}
@@ -295,33 +304,33 @@ func (ctn *Connection) IsConnected() bool {
 // the function will return a TIMEOUT error.
 func (ctn *Connection) updateDeadline() Error {
 	now := time.Now()
-	var socketDeadline time.Time
+	ctn.socketDeadline = now.Add(_DEFAULT_TIMEOUT)
 	if ctn.deadline.IsZero() {
 		if ctn.socketTimeout > 0 {
-			socketDeadline = now.Add(ctn.socketTimeout)
+			ctn.socketDeadline = now.Add(ctn.socketTimeout)
 		}
 	} else {
-		if now.After(ctn.deadline) {
+		if !ctn.deadline.IsZero() && now.After(ctn.deadline) {
 			return newError(types.TIMEOUT)
 		}
-		if ctn.socketTimeout == 0 {
-			socketDeadline = ctn.deadline
+		if ctn.socketTimeout <= 0 {
+			ctn.socketDeadline = ctn.deadline
 		} else {
 			tDeadline := now.Add(ctn.socketTimeout)
 			if tDeadline.After(ctn.deadline) {
-				socketDeadline = ctn.deadline
+				ctn.socketDeadline = ctn.deadline
 			} else {
-				socketDeadline = tDeadline
+				ctn.socketDeadline = tDeadline
 			}
 		}
 
 		// floor to a millisecond to avoid too short timeouts
-		if socketDeadline.Sub(now) < time.Millisecond {
-			socketDeadline = now.Add(time.Millisecond)
+		if ctn.socketDeadline.Sub(now) < time.Millisecond {
+			ctn.socketDeadline = now.Add(time.Millisecond)
 		}
 	}
 
-	if err := ctn.conn.SetDeadline(socketDeadline); err != nil {
+	if err := ctn.conn.SetDeadline(ctn.socketDeadline); err != nil {
 		if ctn.node != nil {
 			ctn.node.stats.ConnectionsFailed.IncrementAndGet()
 		}
@@ -332,10 +341,22 @@ func (ctn *Connection) updateDeadline() Error {
 }
 
 // SetTimeout sets connection timeout for both read and write operations.
-func (ctn *Connection) SetTimeout(deadline time.Time, socketTimeout time.Duration) Error {
-	ctn.deadline = deadline
-	ctn.socketTimeout = socketTimeout
+func (ctn *Connection) SetTimeout(totalTimeout, socketTimeout time.Duration) Error {
+	now := time.Now()
+	ctn.socketTimeout = _DEFAULT_TIMEOUT
+	ctn.deadline = time.Time{}
 
+	if socketTimeout > 0 {
+		ctn.socketTimeout = socketTimeout
+	}
+
+	// keep the deadline.IsZero() == true if totalTimeout is not set
+	if totalTimeout > 0 {
+		ctn.deadline = now.Add(totalTimeout)
+		if socketTimeout <= 0 {
+			ctn.socketTimeout = totalTimeout
+		}
+	}
 	return nil
 }
 

--- a/connection.go
+++ b/connection.go
@@ -263,14 +263,6 @@ func (ctn *Connection) Read(buf []byte, length int) (total int, aerr Error) {
 		}
 		total += r
 		if err != nil {
-			time.Sleep(time.Millisecond)
-			if netErr, ok := err.(net.Error); ok {
-				if netErr.Timeout() && r > 0 {
-					// We had a timeout, but we also read some data;
-					// Continue to read as long as the totalDeadline is not reached
-					continue
-				}
-			}
 			break
 		}
 	}

--- a/connection_heap.go
+++ b/connection_heap.go
@@ -165,9 +165,7 @@ func (h *singleConnectionHeap) RefreshIdleTail(tendInterval time.Duration) bool 
 
 			// refresh in a goroutine asynchronously
 			go func() {
-				timeout := time.Second
-				deadline := time.Now().Add(timeout)
-				conn.SetTimeout(deadline, timeout)
+				conn.SetTimeout(time.Second, time.Second)
 				conn.refresh()
 				if _, err := conn.RequestInfo("build"); err == nil {
 					// return to the pool

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,69 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aerospike_test
+
+import (
+	"fmt"
+	"time"
+
+	as "github.com/aerospike/aerospike-client-go/v8"
+
+	gg "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+)
+
+// ALL tests are isolated by SetName and Key, which are 50 random characters
+var _ = gg.Describe("Connection Test", func() {
+	var conn *as.Connection
+
+	type testExpectations struct {
+		totalTimeout, socketTimeout time.Duration
+		expTotalDeadline            time.Time
+		expSocketDeadline           time.Time
+		expSocketTimeout            time.Duration
+	}
+
+	gg.BeforeEach(func() {
+		var err as.Error
+		conn, err = as.NewConnection(clientPolicy, dbHosts[0])
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		gm.Expect(conn).ToNot(gm.BeNil())
+	})
+
+	gg.It("Dealines should be calculated correctly", func() {
+		testMatrix := []testExpectations{
+			{0, 0, time.Time{}, time.Now().Add(as.DefaultTimeout()), as.DefaultTimeout()},
+			{0, time.Second, time.Time{}, time.Now().Add(time.Second), time.Second},
+			{time.Second, 0, time.Now().Add(time.Second), time.Now().Add(time.Second), time.Second},
+			{5 * time.Second, time.Second, time.Now().Add(5 * time.Second), time.Now().Add(time.Second), time.Second},
+		}
+
+		for _, matrix := range testMatrix {
+			gg.By(fmt.Sprintf("TotalTimeout: %v, SocketTimeout: %v", matrix.totalTimeout, matrix.socketTimeout))
+			err := conn.SetTimeout(matrix.totalTimeout, matrix.socketTimeout)
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			expTotalDeadline, expSocketDeadline, expSocketTimeout, err := conn.UpdateDeadline()
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			gg.By(fmt.Sprintf("expTotalDeadline: %v, expSocketDeadline: %v, expSocketTimeout: %v", matrix.expTotalDeadline, matrix.expSocketDeadline, matrix.expSocketTimeout))
+
+			gm.Expect(expTotalDeadline).To(gm.BeTemporally("~", matrix.expTotalDeadline, time.Millisecond))
+			gm.Expect(expSocketDeadline).To(gm.BeTemporally("~", matrix.expSocketDeadline, time.Millisecond))
+			gm.Expect(expSocketTimeout).To(gm.Equal(matrix.expSocketTimeout))
+		}
+	})
+
+})

--- a/helper_test.go
+++ b/helper_test.go
@@ -14,6 +14,12 @@
 
 package aerospike
 
+import "time"
+
+func DefaultTimeout() time.Duration {
+	return _DEFAULT_TIMEOUT
+}
+
 func ParseInfoErrorCode(response string) Error {
 	return parseInfoErrorCode(response)
 }
@@ -96,4 +102,9 @@ func (cmd *deleteCommand) WriteBuffer(ifc command) Error {
 
 func (cmd *deleteCommand) Buffer() []byte {
 	return cmd.dataBuffer[:cmd.dataOffset]
+}
+
+func (ctn *Connection) UpdateDeadline() (time.Time, time.Time, time.Duration, Error) {
+	err := ctn.updateDeadline()
+	return ctn.deadline, ctn.socketDeadline, ctn.socketTimeout, err
 }

--- a/login_command.go
+++ b/login_command.go
@@ -93,11 +93,7 @@ func (lcmd *loginCommand) login(policy *ClientPolicy, conn *Connection, hashedPa
 
 	lcmd.writeSize()
 
-	var deadline time.Time
-	if policy.LoginTimeout > 0 {
-		deadline = time.Now().Add(policy.Timeout)
-	}
-	conn.SetTimeout(deadline, policy.LoginTimeout)
+	conn.SetTimeout(policy.LoginTimeout, policy.LoginTimeout)
 
 	if _, err := conn.Write(lcmd.dataBuffer[:lcmd.dataOffset]); err != nil {
 		return err

--- a/multi_command.go
+++ b/multi_command.go
@@ -113,7 +113,7 @@ func (cmd *baseMultiCommand) prepareRetry(ifc command, isTimeout bool) bool {
 }
 
 func (cmd *baseMultiCommand) getConnection(policy Policy) (*Connection, Error) {
-	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().deadline(), policy.GetBasePolicy().socketTimeout(), byte(rand.Int63()&0xff))
+	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().TotalTimeout, policy.GetBasePolicy().SocketTimeout, byte(rand.Int63()&0xff))
 }
 
 func (cmd *baseMultiCommand) putConnection(conn *Connection) {

--- a/multi_policy.go
+++ b/multi_policy.go
@@ -40,8 +40,11 @@ type MultiPolicy struct {
 	MaxRecords int64
 
 	// RecordsPerSecond limits returned records per second (rps) rate for each server.
-	// Will not apply rps limit if recordsPerSecond is zero (default).
-	// Currently only applicable to a query without a defined filter.
+	// It does not apply rps limit if RecordsPerSecond is zero (default).
+	//
+	// RecordsPerSecond is supported in all primary and secondary index
+	// queries in server versions 6.0+. For background queries, RecordsPerSecond
+	// is bounded by the server config background-query-max-rps.
 	RecordsPerSecond int
 
 	// Number of records to place in queue before blocking.

--- a/node.go
+++ b/node.go
@@ -388,7 +388,7 @@ func (nd *Node) GetConnection(timeout time.Duration) (conn *Connection, err Erro
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
-		conn, err = nd.getConnection(deadline, timeout)
+		conn, err = nd.getConnection(timeout, timeout)
 		if err == nil && conn != nil {
 			return conn, nil
 		}
@@ -410,7 +410,7 @@ func (nd *Node) GetConnection(timeout time.Duration) (conn *Connection, err Erro
 
 // getConnection gets a connection to the node.
 // If no pooled connection is available, a new connection will be created.
-func (nd *Node) getConnection(deadline time.Time, timeout time.Duration) (conn *Connection, err Error) {
+func (nd *Node) getConnection(deadline, timeout time.Duration) (conn *Connection, err Error) {
 	return nd.getConnectionWithHint(deadline, timeout, 0)
 }
 
@@ -513,7 +513,7 @@ func (nd *Node) makeConnectionForPool(hint byte) {
 
 // getConnectionWithHint gets a connection to the node.
 // If no pooled connection is available, a new connection will be created.
-func (nd *Node) getConnectionWithHint(deadline time.Time, timeout time.Duration, hint byte) (conn *Connection, err Error) {
+func (nd *Node) getConnectionWithHint(totalTimeout, socketTimeout time.Duration, hint byte) (conn *Connection, err Error) {
 	if !nd.active.Get() {
 		return nil, ErrServerNotAvailable.err()
 	}
@@ -538,7 +538,7 @@ func (nd *Node) getConnectionWithHint(deadline time.Time, timeout time.Duration,
 		return nil, ErrConnectionPoolEmpty.err()
 	}
 
-	if err = conn.SetTimeout(deadline, timeout); err != nil {
+	if err = conn.SetTimeout(totalTimeout, socketTimeout); err != nil {
 		nd.stats.ConnectionsFailed.IncrementAndGet()
 
 		// Do not put back into pool.
@@ -700,7 +700,6 @@ func (nd *Node) usingTendConn(timeout time.Duration, f func(conn *Connection)) (
 		if timeout <= 0 {
 			timeout = _DEFAULT_TIMEOUT
 		}
-		deadline := time.Now().Add(timeout)
 
 		// if the tend connection is invalid, establish a new connection first
 		if *conn == nil || !(*conn).IsConnected() {
@@ -719,7 +718,7 @@ func (nd *Node) usingTendConn(timeout time.Duration, f func(conn *Connection)) (
 		}
 
 		// Set timeout for tend conn
-		if err = (*conn).SetTimeout(deadline, timeout); err != nil {
+		if err = (*conn).SetTimeout(timeout, timeout); err != nil {
 			return
 		}
 

--- a/policy.go
+++ b/policy.go
@@ -193,50 +193,10 @@ var _ Policy = &BasePolicy{}
 // GetBasePolicy returns embedded BasePolicy in all types that embed this struct.
 func (p *BasePolicy) GetBasePolicy() *BasePolicy { return p }
 
-// socketTimeout validates and then calculates the timeout to be used for the socket
-// based on Timeout and SocketTimeout values.
-func (p *BasePolicy) socketTimeout() time.Duration {
-	if p.TotalTimeout == 0 && p.SocketTimeout == 0 {
-		return 0
-	} else if p.TotalTimeout > 0 && p.SocketTimeout == 0 {
-		return p.TotalTimeout
-	} else if p.TotalTimeout == 0 && p.SocketTimeout > 0 {
-		return p.SocketTimeout
-	} else if p.TotalTimeout > 0 && p.SocketTimeout > 0 {
-		if p.SocketTimeout < p.TotalTimeout {
-			return p.SocketTimeout
-		}
-	}
-	return p.TotalTimeout
-}
-
-func (p *BasePolicy) timeout() time.Duration {
-	if p.TotalTimeout == 0 && p.SocketTimeout == 0 {
-		return 0
-	} else if p.TotalTimeout > 0 && p.SocketTimeout == 0 {
-		return p.TotalTimeout
-	} else if p.TotalTimeout == 0 && p.SocketTimeout > 0 {
-		return p.SocketTimeout
-	} else if p.TotalTimeout > 0 && p.SocketTimeout > 0 {
-		if p.SocketTimeout < p.TotalTimeout {
-			return p.SocketTimeout
-		}
-	}
-	return p.TotalTimeout
-}
-
 func (p *BasePolicy) deadline() time.Time {
 	var deadline time.Time
-	if p != nil {
-		if p.TotalTimeout > 0 {
-			deadline = time.Now().Add(p.TotalTimeout)
-		} else if p.SocketTimeout > 0 {
-			if p.MaxRetries > 0 {
-				deadline = time.Now().Add(time.Duration(p.MaxRetries) * p.SocketTimeout)
-			} else {
-				deadline = time.Now().Add(p.SocketTimeout)
-			}
-		}
+	if p != nil && p.TotalTimeout > 0 {
+		deadline = time.Now().Add(p.TotalTimeout)
 	}
 
 	return deadline

--- a/single_command.go
+++ b/single_command.go
@@ -36,7 +36,7 @@ func newSingleCommand(cluster *Cluster, key *Key, partition *Partition) singleCo
 }
 
 func (cmd *singleCommand) getConnection(policy Policy) (*Connection, Error) {
-	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().deadline(), policy.GetBasePolicy().socketTimeout(), cmd.key.digest[0])
+	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().TotalTimeout, policy.GetBasePolicy().SocketTimeout, cmd.key.digest[0])
 }
 
 func (cmd *singleCommand) putConnection(conn *Connection) {

--- a/txn.go
+++ b/txn.go
@@ -173,8 +173,8 @@ func (txn *Txn) WriteExistsForKey(key *Key) bool {
 }
 
 // Return Transaction namespace.
-func (txn *Txn) GetNamespace() string {
-	return *txn.namespace
+func (txn *Txn) GetNamespace() *string {
+	return txn.namespace
 }
 
 // Verify current Transaction state and namespace for a future read command.

--- a/txn_error.go
+++ b/txn_error.go
@@ -45,8 +45,9 @@ func NewTxnCommitError(err CommitError, verifyRecords, rollRecords []*BatchRecor
 		}
 	}
 
+	embed := newError(types.TXN_FAILED, string(err)).wrap(cause)
 	return &TxnError{
-		AerospikeError: *(cause.(*AerospikeError)),
+		AerospikeError: *(embed.(*AerospikeError)),
 		CommitError:    err,
 		VerifyRecords:  verifyRecords,
 		RollRecords:    rollRecords,

--- a/txn_monitor.go
+++ b/txn_monitor.go
@@ -172,6 +172,9 @@ func (tm *TxnMonitor) copyTimeoutPolicy(policy *BasePolicy) *WritePolicy {
 }
 
 func getTxnMonitorKey(txn *Txn) *Key {
-	key, _ := NewKey(txn.GetNamespace(), "<ERO~MRT", txn.Id())
-	return key
+	if txn.GetNamespace() != nil {
+		key, _ := NewKey(*txn.GetNamespace(), "<ERO~MRT", txn.Id())
+		return key
+	}
+	return nil
 }

--- a/txn_roll.go
+++ b/txn_roll.go
@@ -47,7 +47,7 @@ func (txr *TxnRoll) Verify(verifyPolicy, rollPolicy *BatchPolicy) Error {
 
 			txnKey := getTxnMonitorKey(txr.txn)
 			if err := txr.Close(writePolicy, txnKey); err != nil {
-				return NewTxnCommitError(CommitErrorVerifyFailAbortAbandoned, txr.verifyRecords, txr.rollRecords, err)
+				return NewTxnCommitError(CommitErrorVerifyFailCloseAbandoned, txr.verifyRecords, txr.rollRecords, err)
 			}
 		}
 
@@ -65,7 +65,7 @@ func (txr *TxnRoll) Commit(rollPolicy *BatchPolicy) (CommitStatus, Error) {
 
 	if txr.txn.MonitorExists() {
 		if err := txr.MarkRollForward(writePolicy, txnKey); err != nil {
-			aec := NewTxnCommitError(CommitErrorVerifyFailAbortAbandoned, txr.verifyRecords, txr.rollRecords, err)
+			aec := NewTxnCommitError(CommitErrorMarkRollForwardAbandoned, txr.verifyRecords, txr.rollRecords, err)
 
 			if err.resultCode() == types.MRT_ABORTED {
 				aec.markInDoubt(false)

--- a/txn_test.go
+++ b/txn_test.go
@@ -30,7 +30,7 @@ import (
 // ALL tests are isolated by SetName and Key, which are 50 random characters
 var _ = gg.Describe("Aerospike", func() {
 
-	gg.Describe("Multi Record Transaction (Transaction) operations", gg.Ordered, func() {
+	gg.Describe("Multi Record Transaction operations", gg.Ordered, func() {
 		var ns = *namespace
 		var set = randString(50)
 		const binName = "bin"
@@ -75,6 +75,26 @@ var _ = gg.Describe("Aerospike", func() {
 			gm.Expect(err).ToNot(gm.HaveOccurred())
 			gm.Expect(<-regTask.OnComplete()).ToNot(gm.HaveOccurred())
 		})
+
+		gg.Context("must support empty transactions", func() {
+
+			gg.It("Committing should not panic", func() {
+				txn := as.NewTxn()
+
+				status, err := client.Commit(txn)
+				gm.Expect(err).ToNot(gm.HaveOccurred())
+				gm.Expect(status).To(gm.Equal(as.CommitStatusOK))
+			}) // it
+
+			gg.It("Canceling should not panic", func() {
+				txn := as.NewTxn()
+
+				status, err := client.Abort(txn)
+				gm.Expect(err).ToNot(gm.HaveOccurred())
+				gm.Expect(status).To(gm.Equal(as.AbortStatusOK))
+			}) // it
+
+		}) // Context
 
 		gg.It("must write and commit", func() {
 			key, _ := as.NewKey(ns, set, randString(50))


### PR DESCRIPTION

- **Fixes**
  - [CLIENT-3379] Setting `TotalTimeout` to 0 causes Scan / Query to fail (timeout).
  - [CLIENT-3376] `BatchRead` on Non-Existing namespace with transaction policy does not throw expected error.
  - [CLIENT-3353] Insufficient Error Messages from MRT commit failure.
  - [CLIENT-3374] Fix panic when trying to commit a MRT with no read and write transaction.

- **Improvements**
  - [CLIENT-3361] Update documentation for `RecordsPerSecond` scan/query policy.


[CLIENT-3379]: https://aerospike.atlassian.net/browse/CLIENT-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3376]: https://aerospike.atlassian.net/browse/CLIENT-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3353]: https://aerospike.atlassian.net/browse/CLIENT-3353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3374]: https://aerospike.atlassian.net/browse/CLIENT-3374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-3361]: https://aerospike.atlassian.net/browse/CLIENT-3361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ