### PR TITLE
Go Client v7.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change History
 
 
+## April 29 2025: v7.10.0
+
+- **Fixes**
+  - [CLIENT-3379] Setting TotalTimeout to 0 causes Scan / Query to fail (timeout)
+
 ## February 26 2025: v7.9.0
 
 - **New Features**

--- a/admin_command.go
+++ b/admin_command.go
@@ -396,7 +396,7 @@ func (acmd *AdminCommand) executeCommand(conn *Connection, policy *AdminPolicy) 
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := conn.SetTimeout(timeout, timeout); err != nil {
 		return err
 	}
 
@@ -426,7 +426,7 @@ func (acmd *AdminCommand) readUsers(conn *Connection, policy *AdminPolicy) ([]*U
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := conn.SetTimeout(timeout, timeout); err != nil {
 		return nil, err
 	}
 
@@ -579,7 +579,7 @@ func (acmd *AdminCommand) readRoles(conn *Connection, policy *AdminPolicy) ([]*R
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := conn.SetTimeout(timeout, timeout); err != nil {
 		return nil, err
 	}
 

--- a/admin_command.go
+++ b/admin_command.go
@@ -396,7 +396,7 @@ func (acmd *AdminCommand) executeCommand(conn *Connection, policy *AdminPolicy) 
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(timeout, timeout); err != nil {
+	if err := conn.setTimeout(timeout, timeout); err != nil {
 		return err
 	}
 
@@ -426,7 +426,7 @@ func (acmd *AdminCommand) readUsers(conn *Connection, policy *AdminPolicy) ([]*U
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(timeout, timeout); err != nil {
+	if err := conn.setTimeout(timeout, timeout); err != nil {
 		return nil, err
 	}
 
@@ -579,7 +579,7 @@ func (acmd *AdminCommand) readRoles(conn *Connection, policy *AdminPolicy) ([]*R
 		timeout = policy.Timeout
 	}
 
-	if err := conn.SetTimeout(timeout, timeout); err != nil {
+	if err := conn.setTimeout(timeout, timeout); err != nil {
 		return nil, err
 	}
 

--- a/aerospike_suite_test.go
+++ b/aerospike_suite_test.go
@@ -63,6 +63,7 @@ var (
 	clientPolicy *as.ClientPolicy
 	client       as.ClientIfc
 	nativeClient *as.Client
+	dbHosts      []*as.Host
 )
 
 func initTestVars() {
@@ -102,8 +103,6 @@ func initTestVars() {
 	tlsConfig = initTLS()
 	clientPolicy.TlsConfig = tlsConfig
 	clientPolicy.UseServicesAlternate = *UseServicesAlternate
-
-	var dbHosts []*as.Host
 
 	if len(strings.TrimSpace(*hosts)) > 0 {
 		dbHosts, err = as.NewHosts(strings.Split(*hosts, ",")...)

--- a/command.go
+++ b/command.go
@@ -2601,7 +2601,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 			if !ifc.prepareRetry(ifc, isClientTimeout || (err != nil && err.Matches(types.SERVER_NOT_AVAILABLE))) {
 				if bc, ok := ifc.(batcher); ok {
 					// Batch may be retried in separate commands.
-					alreadyRetried, err := bc.retryBatch(bc, cmd.node.cluster, deadline, cmd.commandSentCounter)
+					alreadyRetried, err := bc.retryBatch(bc, cmd.node.cluster, cmd.commandSentCounter)
 					if alreadyRetried {
 						// Batch was retried in separate subcommands. Complete this command.
 						applyTransactionMetrics(cmd.node, ifc.transactionType(), transStart)

--- a/connection.go
+++ b/connection.go
@@ -173,7 +173,7 @@ func newConnection(address string, timeout time.Duration) (*Connection, Error) {
 	newConn.limitReader = &io.LimitedReader{R: conn, N: 0}
 
 	// set timeout at the last possible moment
-	if err := newConn.SetTimeout(timeout, timeout); err != nil {
+	if err := newConn.setTimeout(timeout, timeout); err != nil {
 		newConn.Close()
 		return nil, err
 	}
@@ -417,7 +417,16 @@ func (ctn *Connection) updateDeadline() Error {
 }
 
 // SetTimeout sets connection timeout for both read and write operations.
-func (ctn *Connection) SetTimeout(totalTimeout, socketTimeout time.Duration) Error {
+func (ctn *Connection) setTimeout(totalTimeout, socketTimeout time.Duration) Error {
+	var deadline time.Time
+	if totalTimeout > 0 {
+		deadline = time.Now().Add(totalTimeout)
+	}
+	return ctn.SetTimeout(deadline, socketTimeout)
+}
+
+// SetTimeout sets connection timeout for both read and write operations.
+func (ctn *Connection) SetTimeout(deadline time.Time, socketTimeout time.Duration) Error {
 	now := time.Now()
 	ctn.socketTimeout = _DEFAULT_TIMEOUT
 	ctn.deadline = time.Time{}
@@ -427,10 +436,10 @@ func (ctn *Connection) SetTimeout(totalTimeout, socketTimeout time.Duration) Err
 	}
 
 	// keep the deadline.IsZero() == true if totalTimeout is not set
-	if totalTimeout > 0 {
-		ctn.deadline = now.Add(totalTimeout)
+	if !deadline.IsZero() {
+		ctn.deadline = deadline
 		if socketTimeout <= 0 {
-			ctn.socketTimeout = totalTimeout
+			ctn.socketTimeout = deadline.Sub(now)
 		}
 	}
 	return nil

--- a/connection.go
+++ b/connection.go
@@ -64,8 +64,9 @@ type Connection struct {
 	node *Node
 
 	// timeouts
-	socketTimeout time.Duration
-	deadline      time.Time
+	socketTimeout  time.Duration
+	deadline       time.Time
+	socketDeadline time.Time // this is not strictly required, but is used in testing
 
 	// duration after which connection is considered idle
 	idleTimeout  time.Duration
@@ -172,7 +173,7 @@ func newConnection(address string, timeout time.Duration) (*Connection, Error) {
 	newConn.limitReader = &io.LimitedReader{R: conn, N: 0}
 
 	// set timeout at the last possible moment
-	if err := newConn.SetTimeout(time.Now().Add(timeout), timeout); err != nil {
+	if err := newConn.SetTimeout(timeout, timeout); err != nil {
 		newConn.Close()
 		return nil, err
 	}
@@ -379,33 +380,33 @@ func (ctn *Connection) IsConnected() bool {
 // the function will return a TIMEOUT error.
 func (ctn *Connection) updateDeadline() Error {
 	now := time.Now()
-	var socketDeadline time.Time
+	ctn.socketDeadline = now.Add(_DEFAULT_TIMEOUT)
 	if ctn.deadline.IsZero() {
 		if ctn.socketTimeout > 0 {
-			socketDeadline = now.Add(ctn.socketTimeout)
+			ctn.socketDeadline = now.Add(ctn.socketTimeout)
 		}
 	} else {
-		if now.After(ctn.deadline) {
+		if !ctn.deadline.IsZero() && now.After(ctn.deadline) {
 			return newError(types.TIMEOUT)
 		}
-		if ctn.socketTimeout == 0 {
-			socketDeadline = ctn.deadline
+		if ctn.socketTimeout <= 0 {
+			ctn.socketDeadline = ctn.deadline
 		} else {
 			tDeadline := now.Add(ctn.socketTimeout)
 			if tDeadline.After(ctn.deadline) {
-				socketDeadline = ctn.deadline
+				ctn.socketDeadline = ctn.deadline
 			} else {
-				socketDeadline = tDeadline
+				ctn.socketDeadline = tDeadline
 			}
 		}
 
 		// floor to a millisecond to avoid too short timeouts
-		if socketDeadline.Sub(now) < time.Millisecond {
-			socketDeadline = now.Add(time.Millisecond)
+		if ctn.socketDeadline.Sub(now) < time.Millisecond {
+			ctn.socketDeadline = now.Add(time.Millisecond)
 		}
 	}
 
-	if err := ctn.conn.SetDeadline(socketDeadline); err != nil {
+	if err := ctn.conn.SetDeadline(ctn.socketDeadline); err != nil {
 		if ctn.node != nil {
 			ctn.node.stats.ConnectionsFailed.IncrementAndGet()
 		}
@@ -416,10 +417,22 @@ func (ctn *Connection) updateDeadline() Error {
 }
 
 // SetTimeout sets connection timeout for both read and write operations.
-func (ctn *Connection) SetTimeout(deadline time.Time, socketTimeout time.Duration) Error {
-	ctn.deadline = deadline
-	ctn.socketTimeout = socketTimeout
+func (ctn *Connection) SetTimeout(totalTimeout, socketTimeout time.Duration) Error {
+	now := time.Now()
+	ctn.socketTimeout = _DEFAULT_TIMEOUT
+	ctn.deadline = time.Time{}
 
+	if socketTimeout > 0 {
+		ctn.socketTimeout = socketTimeout
+	}
+
+	// keep the deadline.IsZero() == true if totalTimeout is not set
+	if totalTimeout > 0 {
+		ctn.deadline = now.Add(totalTimeout)
+		if socketTimeout <= 0 {
+			ctn.socketTimeout = totalTimeout
+		}
+	}
 	return nil
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -43,6 +43,13 @@ var _ = gg.Describe("Connection Test", func() {
 	})
 
 	gg.It("Dealines should be calculated correctly", func() {
+		deadline := func(timeout time.Duration) (res time.Time) {
+			if timeout > 0 {
+				res = time.Now().Add(timeout)
+			}
+			return res
+		}
+
 		testMatrix := []testExpectations{
 			{0, 0, time.Time{}, time.Now().Add(as.DefaultTimeout()), as.DefaultTimeout()},
 			{0, time.Second, time.Time{}, time.Now().Add(time.Second), time.Second},
@@ -52,7 +59,7 @@ var _ = gg.Describe("Connection Test", func() {
 
 		for _, matrix := range testMatrix {
 			gg.By(fmt.Sprintf("TotalTimeout: %v, SocketTimeout: %v", matrix.totalTimeout, matrix.socketTimeout))
-			err := conn.SetTimeout(matrix.totalTimeout, matrix.socketTimeout)
+			err := conn.SetTimeout(deadline(matrix.totalTimeout), matrix.socketTimeout)
 			gm.Expect(err).ToNot(gm.HaveOccurred())
 
 			expTotalDeadline, expSocketDeadline, expSocketTimeout, err := conn.UpdateDeadline()
@@ -62,7 +69,7 @@ var _ = gg.Describe("Connection Test", func() {
 
 			gm.Expect(expTotalDeadline).To(gm.BeTemporally("~", matrix.expTotalDeadline, time.Millisecond))
 			gm.Expect(expSocketDeadline).To(gm.BeTemporally("~", matrix.expSocketDeadline, time.Millisecond))
-			gm.Expect(expSocketTimeout).To(gm.Equal(matrix.expSocketTimeout))
+			gm.Expect(expSocketTimeout).To(gm.BeNumerically("~", matrix.expSocketTimeout, time.Millisecond))
 		}
 	})
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,69 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aerospike_test
+
+import (
+	"fmt"
+	"time"
+
+	as "github.com/aerospike/aerospike-client-go/v7"
+
+	gg "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+)
+
+// ALL tests are isolated by SetName and Key, which are 50 random characters
+var _ = gg.Describe("Connection Test", func() {
+	var conn *as.Connection
+
+	type testExpectations struct {
+		totalTimeout, socketTimeout time.Duration
+		expTotalDeadline            time.Time
+		expSocketDeadline           time.Time
+		expSocketTimeout            time.Duration
+	}
+
+	gg.BeforeEach(func() {
+		var err as.Error
+		conn, err = as.NewConnection(clientPolicy, dbHosts[0])
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		gm.Expect(conn).ToNot(gm.BeNil())
+	})
+
+	gg.It("Dealines should be calculated correctly", func() {
+		testMatrix := []testExpectations{
+			{0, 0, time.Time{}, time.Now().Add(as.DefaultTimeout()), as.DefaultTimeout()},
+			{0, time.Second, time.Time{}, time.Now().Add(time.Second), time.Second},
+			{time.Second, 0, time.Now().Add(time.Second), time.Now().Add(time.Second), time.Second},
+			{5 * time.Second, time.Second, time.Now().Add(5 * time.Second), time.Now().Add(time.Second), time.Second},
+		}
+
+		for _, matrix := range testMatrix {
+			gg.By(fmt.Sprintf("TotalTimeout: %v, SocketTimeout: %v", matrix.totalTimeout, matrix.socketTimeout))
+			err := conn.SetTimeout(matrix.totalTimeout, matrix.socketTimeout)
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			expTotalDeadline, expSocketDeadline, expSocketTimeout, err := conn.UpdateDeadline()
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			gg.By(fmt.Sprintf("expTotalDeadline: %v, expSocketDeadline: %v, expSocketTimeout: %v", matrix.expTotalDeadline, matrix.expSocketDeadline, matrix.expSocketTimeout))
+
+			gm.Expect(expTotalDeadline).To(gm.BeTemporally("~", matrix.expTotalDeadline, time.Millisecond))
+			gm.Expect(expSocketDeadline).To(gm.BeTemporally("~", matrix.expSocketDeadline, time.Millisecond))
+			gm.Expect(expSocketTimeout).To(gm.Equal(matrix.expSocketTimeout))
+		}
+	})
+
+})

--- a/helper_test.go
+++ b/helper_test.go
@@ -14,6 +14,12 @@
 
 package aerospike
 
+import "time"
+
+func DefaultTimeout() time.Duration {
+	return _DEFAULT_TIMEOUT
+}
+
 func ParseInfoErrorCode(response string) Error {
 	return parseInfoErrorCode(response)
 }
@@ -49,4 +55,9 @@ func (nd *Node) ConnsCount() int {
 // CloseConnections closes all the node connections
 func (nd *Node) CloseConnections() {
 	nd.closeConnections()
+}
+
+func (ctn *Connection) UpdateDeadline() (time.Time, time.Time, time.Duration, Error) {
+	err := ctn.updateDeadline()
+	return ctn.deadline, ctn.socketDeadline, ctn.socketTimeout, err
 }

--- a/login_command.go
+++ b/login_command.go
@@ -93,11 +93,7 @@ func (lcmd *loginCommand) login(policy *ClientPolicy, conn *Connection, hashedPa
 
 	lcmd.writeSize()
 
-	var deadline time.Time
-	if policy.LoginTimeout > 0 {
-		deadline = time.Now().Add(policy.Timeout)
-	}
-	conn.SetTimeout(deadline, policy.LoginTimeout)
+	conn.SetTimeout(policy.LoginTimeout, policy.LoginTimeout)
 
 	if _, err := conn.Write(lcmd.dataBuffer[:lcmd.dataOffset]); err != nil {
 		return err

--- a/login_command.go
+++ b/login_command.go
@@ -93,7 +93,7 @@ func (lcmd *loginCommand) login(policy *ClientPolicy, conn *Connection, hashedPa
 
 	lcmd.writeSize()
 
-	conn.SetTimeout(policy.LoginTimeout, policy.LoginTimeout)
+	conn.setTimeout(policy.LoginTimeout, policy.LoginTimeout)
 
 	if _, err := conn.Write(lcmd.dataBuffer[:lcmd.dataOffset]); err != nil {
 		return err

--- a/multi_command.go
+++ b/multi_command.go
@@ -114,7 +114,7 @@ func (cmd *baseMultiCommand) prepareRetry(ifc command, isTimeout bool) bool {
 }
 
 func (cmd *baseMultiCommand) getConnection(policy Policy) (*Connection, Error) {
-	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().deadline(), policy.GetBasePolicy().socketTimeout(), byte(rand.Int63()&0xff))
+	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().TotalTimeout, policy.GetBasePolicy().SocketTimeout, byte(rand.Int63()&0xff))
 }
 
 func (cmd *baseMultiCommand) putConnection(conn *Connection) {

--- a/node.go
+++ b/node.go
@@ -564,7 +564,7 @@ func (nd *Node) getConnectionWithHint(totalTimeout, socketTimeout time.Duration,
 		return nil, ErrConnectionPoolEmpty.err()
 	}
 
-	if err = conn.SetTimeout(totalTimeout, socketTimeout); err != nil {
+	if err = conn.setTimeout(totalTimeout, socketTimeout); err != nil {
 		nd.stats.ConnectionsFailed.IncrementAndGet()
 
 		// Do not put back into pool.
@@ -744,7 +744,7 @@ func (nd *Node) usingTendConn(timeout time.Duration, f func(conn *Connection)) (
 		}
 
 		// Set timeout for tend conn
-		if err = (*conn).SetTimeout(timeout, timeout); err != nil {
+		if err = (*conn).setTimeout(timeout, timeout); err != nil {
 			return
 		}
 

--- a/node.go
+++ b/node.go
@@ -414,7 +414,7 @@ func (nd *Node) GetConnection(timeout time.Duration) (conn *Connection, err Erro
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
-		conn, err = nd.getConnection(deadline, timeout)
+		conn, err = nd.getConnection(timeout, timeout)
 		if err == nil && conn != nil {
 			return conn, nil
 		}
@@ -436,7 +436,7 @@ func (nd *Node) GetConnection(timeout time.Duration) (conn *Connection, err Erro
 
 // getConnection gets a connection to the node.
 // If no pooled connection is available, a new connection will be created.
-func (nd *Node) getConnection(deadline time.Time, timeout time.Duration) (conn *Connection, err Error) {
+func (nd *Node) getConnection(deadline, timeout time.Duration) (conn *Connection, err Error) {
 	return nd.getConnectionWithHint(deadline, timeout, 0)
 }
 
@@ -539,7 +539,7 @@ func (nd *Node) makeConnectionForPool(hint byte) {
 
 // getConnectionWithHint gets a connection to the node.
 // If no pooled connection is available, a new connection will be created.
-func (nd *Node) getConnectionWithHint(deadline time.Time, timeout time.Duration, hint byte) (conn *Connection, err Error) {
+func (nd *Node) getConnectionWithHint(totalTimeout, socketTimeout time.Duration, hint byte) (conn *Connection, err Error) {
 	if !nd.active.Get() {
 		return nil, ErrServerNotAvailable.err()
 	}
@@ -564,7 +564,7 @@ func (nd *Node) getConnectionWithHint(deadline time.Time, timeout time.Duration,
 		return nil, ErrConnectionPoolEmpty.err()
 	}
 
-	if err = conn.SetTimeout(deadline, timeout); err != nil {
+	if err = conn.SetTimeout(totalTimeout, socketTimeout); err != nil {
 		nd.stats.ConnectionsFailed.IncrementAndGet()
 
 		// Do not put back into pool.
@@ -726,7 +726,6 @@ func (nd *Node) usingTendConn(timeout time.Duration, f func(conn *Connection)) (
 		if timeout <= 0 {
 			timeout = _DEFAULT_TIMEOUT
 		}
-		deadline := time.Now().Add(timeout)
 
 		// if the tend connection is invalid, establish a new connection first
 		if *conn == nil || !(*conn).IsConnected() {
@@ -745,7 +744,7 @@ func (nd *Node) usingTendConn(timeout time.Duration, f func(conn *Connection)) (
 		}
 
 		// Set timeout for tend conn
-		if err = (*conn).SetTimeout(deadline, timeout); err != nil {
+		if err = (*conn).SetTimeout(timeout, timeout); err != nil {
 			return
 		}
 

--- a/policy.go
+++ b/policy.go
@@ -187,50 +187,10 @@ var _ Policy = &BasePolicy{}
 // GetBasePolicy returns embedded BasePolicy in all types that embed this struct.
 func (p *BasePolicy) GetBasePolicy() *BasePolicy { return p }
 
-// socketTimeout validates and then calculates the timeout to be used for the socket
-// based on Timeout and SocketTimeout values.
-func (p *BasePolicy) socketTimeout() time.Duration {
-	if p.TotalTimeout == 0 && p.SocketTimeout == 0 {
-		return 0
-	} else if p.TotalTimeout > 0 && p.SocketTimeout == 0 {
-		return p.TotalTimeout
-	} else if p.TotalTimeout == 0 && p.SocketTimeout > 0 {
-		return p.SocketTimeout
-	} else if p.TotalTimeout > 0 && p.SocketTimeout > 0 {
-		if p.SocketTimeout < p.TotalTimeout {
-			return p.SocketTimeout
-		}
-	}
-	return p.TotalTimeout
-}
-
-func (p *BasePolicy) timeout() time.Duration {
-	if p.TotalTimeout == 0 && p.SocketTimeout == 0 {
-		return 0
-	} else if p.TotalTimeout > 0 && p.SocketTimeout == 0 {
-		return p.TotalTimeout
-	} else if p.TotalTimeout == 0 && p.SocketTimeout > 0 {
-		return p.SocketTimeout
-	} else if p.TotalTimeout > 0 && p.SocketTimeout > 0 {
-		if p.SocketTimeout < p.TotalTimeout {
-			return p.SocketTimeout
-		}
-	}
-	return p.TotalTimeout
-}
-
 func (p *BasePolicy) deadline() time.Time {
 	var deadline time.Time
-	if p != nil {
-		if p.TotalTimeout > 0 {
-			deadline = time.Now().Add(p.TotalTimeout)
-		} else if p.SocketTimeout > 0 {
-			if p.MaxRetries > 0 {
-				deadline = time.Now().Add(time.Duration(p.MaxRetries) * p.SocketTimeout)
-			} else {
-				deadline = time.Now().Add(p.SocketTimeout)
-			}
-		}
+	if p != nil && p.TotalTimeout > 0 {
+		deadline = time.Now().Add(p.TotalTimeout)
 	}
 
 	return deadline

--- a/proxy_conv.go
+++ b/proxy_conv.go
@@ -33,7 +33,7 @@ func (fltr *Filter) grpc() *kvs.Filter {
 var simpleCancelFunc = func() {}
 
 func (p *InfoPolicy) grpcDeadlineContext() (context.Context, context.CancelFunc) {
-	timeout := p.timeout()
+	timeout := p.Timeout
 	if timeout <= 0 {
 		return context.Background(), simpleCancelFunc
 
@@ -110,7 +110,7 @@ func (p *BasePolicy) grpc() *kvs.ReadPolicy {
 }
 
 func (p *BasePolicy) grpcDeadlineContext() (context.Context, context.CancelFunc) {
-	timeout := p.timeout()
+	timeout := p.TotalTimeout
 	if timeout <= 0 {
 		return context.Background(), simpleCancelFunc
 

--- a/single_command.go
+++ b/single_command.go
@@ -36,7 +36,7 @@ func newSingleCommand(cluster *Cluster, key *Key, partition *Partition) singleCo
 }
 
 func (cmd *singleCommand) getConnection(policy Policy) (*Connection, Error) {
-	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().deadline(), policy.GetBasePolicy().socketTimeout(), cmd.key.digest[0])
+	return cmd.node.getConnectionWithHint(policy.GetBasePolicy().TotalTimeout, policy.GetBasePolicy().SocketTimeout, cmd.key.digest[0])
 }
 
 func (cmd *singleCommand) putConnection(conn *Connection) {


### PR DESCRIPTION

- **Fixes**
  - [CLIENT-3379] Setting `Policy.TotalTimeout` to 0 causes Scan / Query to fail (timeout)


[CLIENT-3379]: https://aerospike.atlassian.net/browse/CLIENT-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ