### PR TITLE
Go Client v8.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change History
 
+## May 5 2025: v8.2.2
+
+- **Fixes**
+  - [CLIENT-3438] Adding `err` to return in `Node.requestRawInfo`.
+
 ## April 14 2025: v8.2.1
 
 - **Improvements**

--- a/connection.go
+++ b/connection.go
@@ -49,7 +49,7 @@ var (
 	// MinBufferSize specifies the smallest buffer size that would be allocated for connections. Smaller buffer
 	// requests will allocate at least this amount of memory. This protects against allocating too many small
 	// buffers that would require reallocation and putting pressure on the GC.
-	MinBufferSize = 8 * 1024 // 16 KiB
+	MinBufferSize = 8 * 1024 // 8 KiB
 )
 
 // Connection represents a connection with a timeout.

--- a/node.go
+++ b/node.go
@@ -770,7 +770,7 @@ func (nd *Node) requestRawInfo(policy *InfoPolicy, name ...string) (response *in
 			conn.Close()
 		}
 	})
-	return response, nil
+	return response, err
 }
 
 // RequestStats returns statistics for the specified node as a map


### PR DESCRIPTION
- **Fixes**
  - [CLIENT-3438] Adding `err` to return in `Node.requestRawInfo()`.

[CLIENT-3438]: https://aerospike.atlassian.net/browse/CLIENT-3438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ