### PR TITLE
CLIENT-3120 - Replace an existing node in the cluster when a new peer has the same node name, but a different IP address

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -286,7 +286,7 @@ func (clstr *Cluster) tend() Error {
 
 	// find the first host that connects
 	seq.ParDo(peers.peers(), func(_peer *peer) {
-		if clstr.peerExists(peers, _peer.nodeName) {
+		if clstr.peerExists(peers, _peer) {
 			// Node already exists. Do not even try to connect to hosts.
 			return
 		}
@@ -304,7 +304,7 @@ func (clstr *Cluster) tend() Error {
 				logger.Logger.Warn("Peer node `%s` is different than actual node `%s` for host `%s`", _peer.nodeName, nv.name, host)
 			}
 
-			if clstr.peerExists(peers, nv.name) {
+			if clstr.peerExists(peers, _peer) {
 				// Node already exists. Do not even try to connect to hosts.
 				return seq.Break
 			}
@@ -315,6 +315,10 @@ func (clstr *Cluster) tend() Error {
 			partMap.InitDoVal(clstr.getPartitions().clone, func(partMap partitionMap) {
 				node.refreshPartitions(peers, partMap, true)
 			})
+
+			if _peer.replaceNode != nil {
+				peers._nodesToRemove = append(peers._nodesToRemove, _peer.replaceNode)
+			}
 			return seq.Break
 		})
 	})
@@ -330,14 +334,14 @@ func (clstr *Cluster) tend() Error {
 
 	if peers.genChanged.Get() {
 		// Handle nodes changes determined from refreshes.
-		removeList := clstr.findNodesToRemove(peers.refreshCount.Get())
+		clstr.findNodesToRemove(peers)
 
 		// Remove nodes in a batch.
-		for i := range removeList {
-			logger.Logger.Debug("The following nodes will be removed: %s", removeList[i])
+		for i := range peers._nodesToRemove {
+			logger.Logger.Debug("The following nodes will be removed: %s", peers._nodesToRemove[i])
 		}
-		clstr.removeNodes(removeList)
-		clstr.aggregateNodeStats(removeList)
+		clstr.removeNodes(peers._nodesToRemove)
+		clstr.aggregateNodeStats(peers._nodesToRemove)
 	}
 
 	// Add nodes in a batch.
@@ -422,16 +426,32 @@ func (clstr *Cluster) statsCopy() map[string]nodeStats {
 	return res
 }
 
-func (clstr *Cluster) peerExists(peers *peers, nodeName string) bool {
-	node := clstr.findNodeByName(nodeName)
+func (clstr *Cluster) peerExists(peers *peers, peer *peer) bool {
+	node := clstr.findNodeByName(peer.nodeName)
 	if node != nil {
-		node.referenceCount.IncrementAndGet()
-		return true
+		if node.failures.Get() <= 0 || node.host.IsLocalhost() {
+			// If the node does not have cluster tend errors or is localhost,
+			// reject new peer as the IP address does not need to change.
+			node.referenceCount.IncrementAndGet()
+			return true
+		}
+
+		for _, host := range peer.hosts {
+			if host.equals(node.host) {
+				// Main node host is also the same as one of the peer hosts.
+				// Peer should not be added.
+				node.referenceCount.IncrementAndGet()
+				return true
+			}
+		}
+		peer.replaceNode = node
 	}
 
-	node = peers.nodeByName(nodeName)
+	node = peers.nodeByName(peer.nodeName)
 	if node != nil {
 		node.referenceCount.IncrementAndGet()
+		peer.replaceNode = nil
+
 		return true
 	}
 
@@ -613,12 +633,13 @@ func (clstr *Cluster) addAlias(host *Host, node *Node) {
 	}
 }
 
-func (clstr *Cluster) findNodesToRemove(refreshCount int) []*Node {
-	removeList := []*Node{}
+func (clstr *Cluster) findNodesToRemove(peers *peers) {
+	refreshCount := peers.refreshCount.Get()
+	removeList := peers._nodesToRemove
 
 	if clstr.clientPolicy.Load().SeedOnlyCluster {
 		// Don't remove any node even if its bad or inactive.
-		return removeList
+		return
 	}
 
 	nodes := clstr.GetNodes()
@@ -656,8 +677,6 @@ func (clstr *Cluster) findNodesToRemove(refreshCount int) []*Node {
 			}
 		}
 	}
-
-	return removeList
 }
 
 func (clstr *Cluster) findNodeInPartitionMap(filter *Node) bool {

--- a/cluster.go
+++ b/cluster.go
@@ -311,11 +311,9 @@ func (clstr *Cluster) tend() Error {
 				node.refreshPartitions(peers, partMap, true)
 			})
 
-			if _peer.replaceNode != nil {
-				// Preventing duplicate entries.
-				if !peers.containsNodeToRemove(_peer.replaceNode) {
+			// Preventing duplicate entries.
+			if _peer.replaceNode != nil && !peers.containsNodeToRemove(_peer.replaceNode) {
 					peers.addNodesToRemove(_peer.replaceNode)
-				}
 			}
 			return seq.Break
 		})

--- a/cluster.go
+++ b/cluster.go
@@ -313,12 +313,9 @@ func (clstr *Cluster) tend() Error {
 
 			if _peer.replaceNode != nil {
 				// Preventing duplicate entries.
-				for _, entry := range peers._nodesToRemove {
-					if entry.Equals(_peer.replaceNode) {
-						return seq.Break
-					}
+				if !peers.containsNodeToRemove(_peer.replaceNode) {
+					peers.addNodesToRemove(_peer.replaceNode)
 				}
-				peers._nodesToRemove = append(peers._nodesToRemove, _peer.replaceNode)
 			}
 			return seq.Break
 		})
@@ -338,11 +335,15 @@ func (clstr *Cluster) tend() Error {
 		clstr.findNodesToRemove(peers)
 
 		// Remove nodes in a batch.
-		for i := range peers._nodesToRemove {
-			logger.Logger.Debug("The following nodes will be removed: %s", peers._nodesToRemove[i])
+		nodesToRemove := peers.getNodesToRemove()
+		for i := range nodesToRemove {
+			logger.Logger.Debug("The following nodes will be removed: %s", nodesToRemove[i])
 		}
-		clstr.removeNodes(peers._nodesToRemove)
-		clstr.aggregateNodeStats(peers._nodesToRemove)
+		clstr.removeNodes(nodesToRemove)
+		clstr.aggregateNodeStats(nodesToRemove)
+
+		// Clear the removal list after processing
+		peers.clearNodesToRemove()
 	}
 
 	// Add nodes in a batch.
@@ -645,7 +646,6 @@ func (clstr *Cluster) addAlias(host *Host, node *Node) {
 
 func (clstr *Cluster) findNodesToRemove(peers *peers) {
 	refreshCount := peers.refreshCount.Get()
-	removeList := peers._nodesToRemove
 
 	if clstr.clientPolicy.Load().SeedOnlyCluster {
 		// Don't remove any node even if its bad or inactive.
@@ -657,7 +657,9 @@ func (clstr *Cluster) findNodesToRemove(peers *peers) {
 	for _, node := range nodes {
 		if !node.IsActive() {
 			// Inactive nodes must be removed.
-			removeList = append(removeList, node)
+			if !peers.containsNodeToRemove(node) {
+				peers.addNodesToRemove(node)
+			}
 			continue
 		}
 
@@ -666,7 +668,9 @@ func (clstr *Cluster) findNodesToRemove(peers *peers) {
 			// All node info requests failed and this node had 5 consecutive failures.
 			// Remove node.  If no nodes are left, seeds will be tried in next cluster
 			// tend iteration.
-			removeList = append(removeList, node)
+			if !peers.containsNodeToRemove(node) {
+				peers.addNodesToRemove(node)
+			}
 			continue
 		}
 
@@ -679,11 +683,15 @@ func (clstr *Cluster) findNodesToRemove(peers *peers) {
 				if !clstr.findNodeInPartitionMap(node) {
 					// Node doesn't have any partitions mapped to it.
 					// There is no point in keeping it in the cluster.
-					removeList = append(removeList, node)
+					if !peers.containsNodeToRemove(node) {
+						peers.addNodesToRemove(node)
+					}
 				}
 			} else {
 				// Node not responding. Remove it.
-				removeList = append(removeList, node)
+				if !peers.containsNodeToRemove(node) {
+					peers.addNodesToRemove(node)
+				}
 			}
 		}
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -304,11 +304,6 @@ func (clstr *Cluster) tend() Error {
 				logger.Logger.Warn("Peer node `%s` is different than actual node `%s` for host `%s`", _peer.nodeName, nv.name, host)
 			}
 
-			if clstr.peerExists(peers, _peer) {
-				// Node already exists. Do not even try to connect to hosts.
-				return seq.Break
-			}
-
 			// Create new node.
 			node := clstr.createNode(&nv)
 			peers.addNode(nv.name, node)
@@ -428,6 +423,7 @@ func (clstr *Cluster) statsCopy() map[string]nodeStats {
 
 func (clstr *Cluster) peerExists(peers *peers, peer *peer) bool {
 	node := clstr.findNodeByName(peer.nodeName)
+
 	if node != nil {
 		if node.failures.Get() <= 0 || node.host.IsLocalhost() {
 			// If the node does not have cluster tend errors or is localhost,
@@ -437,12 +433,20 @@ func (clstr *Cluster) peerExists(peers *peers, peer *peer) bool {
 		}
 
 		for _, host := range peer.hosts {
-			if host.equals(node.host) {
-				// Main node host is also the same as one of the peer hosts.
-				// Peer should not be added.
-				node.referenceCount.IncrementAndGet()
-				return true
+			if host.Port == node.host.Port {
+				if host.Name == node.host.Name || (node.hostName != "" && host.Name == node.hostName) {
+					// Main node host is also the same as one of the peer hosts.
+					// Peer should not be added.
+					if host.IsLocalhost() {
+						node.hostName = host.Name
+					}
+					node.referenceCount.IncrementAndGet()
+
+					logger.Logger.Debug("Peer node `%s` matches existing node `%s` by host `%s`.", peer.nodeName, node.name, host)
+					return true
+				}
 			}
+
 		}
 		peer.replaceNode = node
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -341,9 +341,6 @@ func (clstr *Cluster) tend() Error {
 		}
 		clstr.removeNodes(nodesToRemove)
 		clstr.aggregateNodeStats(nodesToRemove)
-
-		// Clear the removal list after processing
-		peers.clearNodesToRemove()
 	}
 
 	// Add nodes in a batch.

--- a/cluster.go
+++ b/cluster.go
@@ -312,6 +312,12 @@ func (clstr *Cluster) tend() Error {
 			})
 
 			if _peer.replaceNode != nil {
+				// Preventing duplicate entries.
+				for _, entry := range peers._nodesToRemove {
+					if entry.Equals(_peer.replaceNode) {
+						return seq.Break
+					}
+				}
 				peers._nodesToRemove = append(peers._nodesToRemove, _peer.replaceNode)
 			}
 			return seq.Break

--- a/helper_test.go
+++ b/helper_test.go
@@ -132,3 +132,7 @@ func (node *Node) GetErrorCount() int {
 func NewDynConfigForTest(config *dynconfig.Config) *DynConfig {
 	return newDynConfigForTest(config)
 }
+
+func (host *Host) Equals(other *Host) bool {
+	return host.equals(other)
+}

--- a/host.go
+++ b/host.go
@@ -47,7 +47,10 @@ func (h *Host) String() string {
 
 // Implements stringer interface
 func (h *Host) equals(other *Host) bool {
-	return h.Name == other.Name && h.Port == other.Port
+	if other == nil {
+		return false
+	}
+	return h.Name == other.Name && h.Port == other.Port && h.TLSName == other.TLSName
 }
 
 // IsLocalhost returns true if the host name or IP address represents localhost.

--- a/host.go
+++ b/host.go
@@ -50,6 +50,26 @@ func (h *Host) equals(other *Host) bool {
 	return h.Name == other.Name && h.Port == other.Port
 }
 
+// IsLocalhost returns true if the host name or IP address represents localhost.
+// This includes "localhost", IPv4 loopback addresses (127.x.x.x), and IPv6 loopback (::1).
+func (h *Host) IsLocalhost() bool {
+	// Check for common localhost string
+	if h.Name == "localhost" {
+		return true
+	}
+
+	// Parse as IP address
+	ip := net.ParseIP(h.Name)
+	if ip != nil {
+		return ip.IsLoopback()
+	}
+
+	// If not a valid IP, it might be a hostname that we can't determine
+	// without DNS resolution, so we return false for non-IP hostnames
+	// other than "localhost"
+	return false
+}
+
 // NewHosts initializes new host instances by a passed slice of addresses.
 func NewHosts(addresses ...string) ([]*Host, Error) {
 	aerospikeHosts := make([]*Host, 0, len(addresses))

--- a/host_test.go
+++ b/host_test.go
@@ -39,5 +39,74 @@ var _ = gg.Describe("Aerospike", func() {
 			gm.Expect(err).To(gm.HaveOccurred())
 			gm.Expect(hosts).To(gm.BeNil())
 		})
+
+		gg.It("must correctly identify localhost hosts", func() {
+			// Test cases that should return true (localhost)
+			localhostCases := []*as.Host{
+				as.NewHost("localhost", 3000),
+				as.NewHost("127.0.0.1", 3000),
+				as.NewHost("127.0.0.2", 3000),
+				as.NewHost("127.255.255.254", 3000),
+				as.NewHost("::1", 3000),
+			}
+
+			for _, host := range localhostCases {
+				gm.Expect(host.IsLocalhost()).To(gm.BeTrue(), "Expected %s to be localhost", host.Name)
+			}
+
+			// Test cases that should return false (not localhost)
+			nonLocalhostCases := []*as.Host{
+				as.NewHost("192.168.1.1", 3000),
+				as.NewHost("10.0.0.1", 3000),
+				as.NewHost("example.com", 3000),
+				as.NewHost("::2", 3000),
+				as.NewHost("2001:db8::1", 3000),
+				as.NewHost("", 3000), // empty string
+			}
+
+			for _, host := range nonLocalhostCases {
+				gm.Expect(host.IsLocalhost()).To(gm.BeFalse(), "Expected %s to not be localhost", host.Name)
+			}
+		})
+
+		gg.It("must correctly compare Host instances for equality", func() {
+			// Test equal hosts
+			host1 := as.NewHost("localhost", 3000)
+			host2 := as.NewHost("localhost", 3000)
+			gm.Expect(host1.Equals(host2)).To(gm.BeTrue(), "Expected identical hosts to be equal")
+
+			// Test hosts with TLS names
+			host1.TLSName = "tls.example.com"
+			host2.TLSName = "tls.example.com"
+			gm.Expect(host1.Equals(host2)).To(gm.BeTrue(), "Expected hosts with same TLS names to be equal")
+
+			// Test different names
+			host3 := as.NewHost("different-host", 3000)
+			gm.Expect(host1.Equals(host3)).To(gm.BeFalse(), "Expected hosts with different names to not be equal")
+
+			// Test different ports
+			host4 := as.NewHost("localhost", 4000)
+			gm.Expect(host1.Equals(host4)).To(gm.BeFalse(), "Expected hosts with different ports to not be equal")
+
+			// Test different TLS names
+			host5 := as.NewHost("localhost", 3000)
+			host5.TLSName = "different-tls.example.com"
+			gm.Expect(host1.Equals(host5)).To(gm.BeFalse(), "Expected hosts with different TLS names to not be equal")
+
+			// Test nil comparison
+			gm.Expect(host1.Equals(nil)).To(gm.BeFalse(), "Expected host compared with nil to be false")
+
+			// Test empty vs non-empty TLS names
+			host6 := as.NewHost("localhost", 3000)
+			host7 := as.NewHost("localhost", 3000)
+			host6.TLSName = ""
+			host7.TLSName = "tls.example.com"
+			gm.Expect(host6.Equals(host7)).To(gm.BeFalse(), "Expected hosts with different TLS name states to not be equal")
+
+			// Test both empty TLS names
+			host8 := as.NewHost("localhost", 3000)
+			host9 := as.NewHost("localhost", 3000)
+			gm.Expect(host8.Equals(host9)).To(gm.BeTrue(), "Expected hosts with both empty TLS names to be equal")
+		})
 	})
 })

--- a/node.go
+++ b/node.go
@@ -48,6 +48,7 @@ type Node struct {
 	cluster     *Cluster
 	name        string
 	host        *Host
+	hostName    string
 	aliases     iatomic.TypedVal[[]*Host]
 	stats       nodeStats
 	sessionInfo iatomic.TypedVal[*sessionInfo]

--- a/peers.go
+++ b/peers.go
@@ -134,14 +134,6 @@ func (ps *peers) containsNodeToRemove(node *Node) bool {
 	return false
 }
 
-// clearNodesToRemove resets the removal list (call after processing)
-func (ps *peers) clearNodesToRemove() {
-	ps.mutex.Lock()
-	defer ps.mutex.Unlock()
-
-	ps._nodesToRemove = ps._nodesToRemove[:0]
-}
-
 type peer struct {
 	nodeName    string
 	tlsName     string

--- a/peers.go
+++ b/peers.go
@@ -21,21 +21,23 @@ import (
 )
 
 type peers struct {
-	_peers       map[string]*peer
-	_hosts       map[Host]struct{}
-	_nodes       map[string]*Node
-	refreshCount atomic.Int
-	genChanged   atomic.Bool
+	_peers         map[string]*peer
+	_hosts         map[Host]struct{}
+	_nodes         map[string]*Node
+	_nodesToRemove []*Node
+	refreshCount   atomic.Int
+	genChanged     atomic.Bool
 
 	mutex sync.RWMutex
 }
 
 func newPeers(peerCapacity int, addCapacity int) *peers {
 	return &peers{
-		_peers:     make(map[string]*peer, peerCapacity),
-		_hosts:     make(map[Host]struct{}, addCapacity),
-		_nodes:     make(map[string]*Node, addCapacity),
-		genChanged: *atomic.NewBool(true),
+		_peers:         make(map[string]*peer, peerCapacity),
+		_hosts:         make(map[Host]struct{}, addCapacity),
+		_nodes:         make(map[string]*Node, addCapacity),
+		_nodesToRemove: make([]*Node, 0),
+		genChanged:     *atomic.NewBool(true),
 	}
 }
 
@@ -71,7 +73,6 @@ func (ps *peers) appendPeers(peers []*peer) {
 	for _, peer := range peers {
 		ps._peers[peer.nodeName] = peer
 	}
-
 }
 
 func (ps *peers) peers() []*peer {
@@ -92,7 +93,8 @@ func (ps *peers) nodes() map[string]*Node {
 }
 
 type peer struct {
-	nodeName string
-	tlsName  string
-	hosts    []*Host
+	nodeName    string
+	tlsName     string
+	hosts       []*Host
+	replaceNode *Node
 }

--- a/peers.go
+++ b/peers.go
@@ -31,6 +31,7 @@ type peers struct {
 	mutex sync.RWMutex
 }
 
+// newPeers creates a new peers object
 func newPeers(peerCapacity int, addCapacity int) *peers {
 	return &peers{
 		_peers:         make(map[string]*peer, peerCapacity),
@@ -41,6 +42,8 @@ func newPeers(peerCapacity int, addCapacity int) *peers {
 	}
 }
 
+// todo: not used anywhere. Consider removing
+// hostExists checks if a host exists in the hosts map
 func (ps *peers) hostExists(host Host) bool {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
@@ -48,24 +51,29 @@ func (ps *peers) hostExists(host Host) bool {
 	return exists
 }
 
+// todo: not used anywhere. Consider removing
+// addHost adds a host to the hosts map
 func (ps *peers) addHost(host Host) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 	ps._hosts[host] = struct{}{}
 }
 
+// addNode adds a node to the nodes map
 func (ps *peers) addNode(name string, node *Node) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 	ps._nodes[name] = node
 }
 
+// nodeByName returns a node by name
 func (ps *peers) nodeByName(name string) *Node {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
 	return ps._nodes[name]
 }
 
+// appendPeers adds a list of peers to the peers map
 func (ps *peers) appendPeers(peers []*peer) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
@@ -75,6 +83,7 @@ func (ps *peers) appendPeers(peers []*peer) {
 	}
 }
 
+// peers returns a copy of peers for safe iteration
 func (ps *peers) peers() []*peer {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
@@ -86,10 +95,51 @@ func (ps *peers) peers() []*peer {
 	return res
 }
 
+// nodes returns a copy of nodes for safe iteration
 func (ps *peers) nodes() map[string]*Node {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
 	return ps._nodes
+}
+
+// addNodesToRemove adds a node to the removal list
+func (ps *peers) addNodesToRemove(removeNode *Node) {
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
+
+	ps._nodesToRemove = append(ps._nodesToRemove, removeNode)
+}
+
+// getNodesToRemove returns a copy of nodes to remove for safe iteration
+func (ps *peers) getNodesToRemove() []*Node {
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
+
+	// Return a copy to prevent race conditions
+	result := make([]*Node, len(ps._nodesToRemove))
+	copy(result, ps._nodesToRemove)
+	return result
+}
+
+// containsNodeToRemove checks if a node is already marked for removal
+func (ps *peers) containsNodeToRemove(node *Node) bool {
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
+
+	for _, entry := range ps._nodesToRemove {
+		if entry.Equals(node) {
+			return true
+		}
+	}
+	return false
+}
+
+// clearNodesToRemove resets the removal list (call after processing)
+func (ps *peers) clearNodesToRemove() {
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
+
+	ps._nodesToRemove = ps._nodesToRemove[:0]
 }
 
 type peer struct {

--- a/tools/benchmark/benchmark.go
+++ b/tools/benchmark/benchmark.go
@@ -86,6 +86,7 @@ var errorRateWindow = flag.Int("errorRateWindow", 1, "Error Rate Window for the 
 var openingConnectionThreshold = flag.Int("openingConnectionThreshold", 64, "Maximum number of connections allowed to open simultaneously.")
 var warmUp = flag.Int("warmUp", 128, "Number of connections to open on start up.")
 var useCompression = flag.Bool("compress", false, "Use compression to send and receive data from the server.")
+var useServicesAlternate = flag.Bool("sa", false, "Use alternate service addresses.")
 var minConnsPerNode = flag.Int("minConnsPerNode", 0, "Minimum connections to maintain to each node.")
 
 var randBinData = flag.Bool("R", false, "Use dynamically generated random bin values instead of default static fixed bin values.")
@@ -166,15 +167,18 @@ func main() {
 	clientPolicy.Timeout = 10 * time.Second
 	clientPolicy.OpeningConnectionThreshold = *openingConnectionThreshold
 	clientPolicy.MinConnectionsPerNode = *minConnsPerNode
+	clientPolicy.UseServicesAlternate = *useServicesAlternate
 	clientPolicy.TlsConfig = initAerospikeTLS()
+	var client *as.Client
 	dbHost := as.NewHost(*host, *port)
-	dbHost.TLSName = *tlsName
+	if *tlsName != "" {
+		dbHost.TLSName = *tlsName
+	}
 
 	client, err := as.NewClientWithPolicyAndHost(clientPolicy, dbHost)
 	if err != nil {
 		logger.Fatal(err)
 	}
-
 	cc, _ := client.WarmUp(*warmUp)
 	logger.Printf("Warm-up conns.:\t%d", cc)
 	logger.Println("Nodes Found:", client.GetNodeNames())
@@ -244,6 +248,7 @@ func printBenchmarkParams() {
 	logger.Printf("auth mode:\t%s", *authMode)
 	logger.Printf("user:\t\t%s", *user)
 	logger.Printf("password:\t\t%s", *password)
+	logger.Printf("services alternate:\t%v", *useServicesAlternate)
 }
 
 // parses an string of (key:value) type
@@ -513,12 +518,12 @@ func runBench_I(client *as.Client, ident int, times int) {
 			time.Sleep(time.Second - time.Duration(time.Now().UnixNano()-atomic.LoadInt64(&lastReport)))
 		}
 	}
+
 	countReportChan <- &TStats{false, WCount, 0, writeErr, 0, writeTOErr, 0, wMinLat, wMaxLat, 0, 0, wLatTotal, 0, wLatList, nil}
 }
 
 func runBench_RU(client *as.Client, ident int, times int) {
 	defer wg.Done()
-
 	xr := NewXorRand()
 
 	// var r *as.Record


### PR DESCRIPTION
## Changes
**Bug fix:**
Used https://aerospike.atlassian.net/browse/CLIENT-3117 as and [java commit](https://github.com/aerospike/aerospike-client-java/commit/38585450f0f37937dc1cef6ec4b06c83ecb8eff3) as reference for the changes. 

This ticket also takes care of https://aerospike.atlassian.net/browse/CLIENT-3318 since we have added logic to prevent same node being added to remove list if the node is already on the list.
https://github.com/aerospike/aerospike-client-go/blob/c6ffa3e01cc53d3d79c2f07545d9be0577a88cd3/cluster.go#L316

**Validation:**
To validate changes I have used instructions posted [here](https://aerospike.atlassian.net/browse/OPS-7572). 

I was able to validate that on ip change the client was able to update node ipaddress to new ip.

```bash
Removed nodes: [BB93A00800A0142 34.44.198.103:3000]
2025/08/25 21:58:45 benchmark.go:813: write(tps=1 timeouts=0 errors=0) read(tps=0 timeouts=0 errors=0) total(tps=1 timeouts=0 errors=0, count=352)
```

**Added feature:**
Added ability to use service-alternate when using benchmark utility.
