### PR TITLE
CLIENT-3435 Update Go Client to version 1.24 to support FIPS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ name: Aerospike Go Client Tests
 
 env:
   AEROSPIKE_HOSTS: "127.0.0.1:3000"
-  GOFLAGS: -mod=vendor
   GODEBUG: fips140=only
   GOFIPS140: latest
 jobs:
@@ -45,40 +44,40 @@ jobs:
         with:
           server-version: ${{ matrix.server-version }}
       - name: Test Lua Code
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites internal/lua
       - name: Test types package
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites types
       - name: Test pkg tests
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites pkg
       - name: Build Benchmark tool
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: cd tools/benchmark | go build -mod=vendor -tags as_proxy -o benchmark .
       - name: Build asinfo tool
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: cd tools/asinfo | go build -mod=vendor -o asinfo .
       - name: Build cli tool
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: cd tools/cli | go build -mod=vendor -o cli .
       - name: Build example files
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: find examples -name "*.go" -type f -print0 | xargs -0 -n1 go build
       - name: Build with Reflection code removed
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="as_performance" .
       - name: Build for Google App Engine (unsafe package removed)
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="app_engine" .
       - name: Run FIPS Compliance Tests
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -v fips_complience_test.go
       - name: Run the tests
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -coverprofile=./cover_native.out -covermode=atomic -coverpkg=./... -race -keep-going -succinct -randomize-suites -skip="HyperLogLog"
       - name: Combine Cover Profiles
-        env: {GOPROXY: off, GOSUMDB: off}
+        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/wadey/gocovmerge cover_*.out > cover_all.out
       - name: Check Code Coverage
         uses: vladopajic/go-test-coverage@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ env:
   GOFLAGS: -mod=vendor
   GODEBUG: fips140=only
   GOFIPS140: latest
-  GOPROXY: off
-  GOSUMDB: off
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,12 +27,15 @@ jobs:
       - name: Fetch dependencies
         env:
           GODEBUG: fips140=on
-          GOPROXY: on
-          GOSUMDB: on
         run: |
+          # Install all dependencies
           go mod download
+
+          # Install ginkgo CLI and gocovmerge for testing
           go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2
           go mod download github.com/wadey/gocovmerge
+
+          # Vendor the dependencies
           go mod vendor
 
       - name: Display Go version
@@ -44,28 +45,40 @@ jobs:
         with:
           server-version: ${{ matrix.server-version }}
       - name: Test Lua Code
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites internal/lua
       - name: Test types package
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites types
       - name: Test pkg tests
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites pkg
       - name: Build Benchmark tool
+        env: {GOPROXY: off, GOSUMDB: off}
         run: cd tools/benchmark | go build -mod=vendor -tags as_proxy -o benchmark .
       - name: Build asinfo tool
+        env: {GOPROXY: off, GOSUMDB: off}
         run: cd tools/asinfo | go build -mod=vendor -o asinfo .
       - name: Build cli tool
+        env: {GOPROXY: off, GOSUMDB: off}
         run: cd tools/cli | go build -mod=vendor -o cli .
       - name: Build example files
+        env: {GOPROXY: off, GOSUMDB: off}
         run: find examples -name "*.go" -type f -print0 | xargs -0 -n1 go build
       - name: Build with Reflection code removed
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="as_performance" .
       - name: Build for Google App Engine (unsafe package removed)
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="app_engine" .
       - name: Run FIPS Compliance Tests
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -v fips_complience_test.go
       - name: Run the tests
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -coverprofile=./cover_native.out -covermode=atomic -coverpkg=./... -race -keep-going -succinct -randomize-suites -skip="HyperLogLog"
       - name: Combine Cover Profiles
+        env: {GOPROXY: off, GOSUMDB: off}
         run: go run -mod=vendor github.com/wadey/gocovmerge cover_*.out > cover_all.out
       - name: Check Code Coverage
         uses: vladopajic/go-test-coverage@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,6 @@ jobs:
       - name: Build for Google App Engine (unsafe package removed)
         env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="app_engine" .
-      - name: Run FIPS Compliance Tests
-        env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
-        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -v fips_complience_test.go
       - name: Run the tests
         env: {GOPROXY: off, GOSUMDB: off, GOFLAGS: -mod=vendor}
         run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -coverprofile=./cover_native.out -covermode=atomic -coverpkg=./... -race -keep-going -succinct -randomize-suites -skip="HyperLogLog"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,11 @@ name: Aerospike Go Client Tests
 
 env:
   AEROSPIKE_HOSTS: "127.0.0.1:3000"
+  GOFLAGS: -mod=vendor
   GODEBUG: fips140=only
   GOFIPS140: latest
+  GOPROXY: off
+  GOSUMDB: off
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,12 +20,23 @@ jobs:
         server-version:
           - 8.1.0.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Setup Go ${{ matrix.go-version }}"
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "${{ matrix.go-version }}"
           cache: true
+      - name: Fetch dependencies
+        env:
+          GODEBUG: fips140=on
+          GOPROXY: on
+          GOSUMDB: on
+        run: |
+          go mod download
+          go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2
+          go mod download github.com/wadey/gocovmerge
+          go mod vendor
+
       - name: Display Go version
         run: go version
       - name: Set up Aerospike Database
@@ -30,29 +44,29 @@ jobs:
         with:
           server-version: ${{ matrix.server-version }}
       - name: Test Lua Code
-        run: go run github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites internal/lua
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites internal/lua
       - name: Test types package
-        run: go run github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites types
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites types
       - name: Test pkg tests
-        run: go run github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites pkg
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -cover -race -r -keep-going -succinct -randomize-suites pkg
       - name: Build Benchmark tool
-        run: cd tools/benchmark | go build -tags as_proxy -o benchmark .
+        run: cd tools/benchmark | go build -mod=vendor -tags as_proxy -o benchmark .
       - name: Build asinfo tool
-        run: cd tools/asinfo | go build -o asinfo .
+        run: cd tools/asinfo | go build -mod=vendor -o asinfo .
       - name: Build cli tool
-        run: cd tools/cli | go build -o cli .
+        run: cd tools/cli | go build -mod=vendor -o cli .
       - name: Build example files
         run: find examples -name "*.go" -type f -print0 | xargs -0 -n1 go build
       - name: Build with Reflection code removed
-        run: go run github.com/onsi/ginkgo/v2/ginkgo build -tags="as_performance" .
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="as_performance" .
       - name: Build for Google App Engine (unsafe package removed)
-        run: go run github.com/onsi/ginkgo/v2/ginkgo build -tags="app_engine" .
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo build -tags="app_engine" .
+      - name: Run FIPS Compliance Tests
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -v fips_complience_test.go
       - name: Run the tests
-        run: go run github.com/onsi/ginkgo/v2/ginkgo -coverprofile=./cover_native.out -covermode=atomic -coverpkg=./... -race -keep-going -succinct -randomize-suites -skip="HyperLogLog"
-      - name: Download gocovmerge
-        run: go mod download github.com/wadey/gocovmerge
+        run: go run -mod=vendor github.com/onsi/ginkgo/v2/ginkgo -coverprofile=./cover_native.out -covermode=atomic -coverpkg=./... -race -keep-going -succinct -randomize-suites -skip="HyperLogLog"
       - name: Combine Cover Profiles
-        run: go run github.com/wadey/gocovmerge cover_*.out > cover_all.out
+        run: go run -mod=vendor github.com/wadey/gocovmerge cover_*.out > cover_all.out
       - name: Check Code Coverage
         uses: vladopajic/go-test-coverage@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,15 +5,17 @@ name: Aerospike Go Client Tests
 
 env:
   AEROSPIKE_HOSTS: "127.0.0.1:3000"
+  GODEBUG: fips140=only
+  GOFIPS140: latest
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version:
-          - 1.23
+          - 1.25.1
         server-version:
-          - 8.1.0.0-rc4_1
+          - 8.1.0.0
     steps:
       - uses: actions/checkout@v3
       - name: "Setup Go ${{ matrix.go-version }}"

--- a/cluster.go
+++ b/cluster.go
@@ -222,7 +222,7 @@ Loop:
 		case <-time.After(tendInterval):
 			tm := time.Now()
 			if err := clstr.tend(); err != nil {
-				logger.Logger.Warn(err.Error())
+				logger.Logger.Warn("%s", err.Error())
 			}
 
 			clientPolicy := clstr.clientPolicy.Load()
@@ -475,7 +475,7 @@ func (clstr *Cluster) waitTillStabilized() Error {
 					default:
 					}
 				}
-				logger.Logger.Warn(err.Error())
+				logger.Logger.Warn("%s", err.Error())
 			}
 
 			// Check to see if cluster has changed since the last Tend().

--- a/command.go
+++ b/command.go
@@ -2779,7 +2779,7 @@ func (cmd *baseCommand) setQuery(policy *QueryPolicy, wpolicy *WritePolicy, stat
 			cmd.writeFieldHeader(expressionSize, INDEX_EXPRESSION)
 			if _, err = statement.Filter.expression.pack(cmd); err != nil {
 				return newCommonError(err)
-			} 
+			}
 		}
 	}
 
@@ -3800,7 +3800,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 				// the command to increase the iteration count.
 				cmd.commandSentCounter--
 			}
-			logger.Logger.Debug("Node " + cmd.node.String() + ": " + err.Error())
+			logger.Logger.Debug("Node %s: %s", cmd.node.String(), err.Error())
 			continue
 		}
 
@@ -3875,7 +3875,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 
 			cmd.conn = nil
 
-			logger.Logger.Debug("Node " + cmd.node.String() + ": " + err.Error())
+			logger.Logger.Debug("Node %s: %s", cmd.node.String(), err.Error())
 			continue
 		}
 
@@ -3884,7 +3884,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 			start := time.Now()
 			err = ifc.parseResult(ifc, cmd.conn)
 			dataReceived := cmd.conn.totalReceived
-			logger.Logger.Debug("Node " + cmd.node.String() + ": " + fmt.Sprintf("Received %d bytes", dataReceived) + ", command type: " + ifc.commandType().String())
+			logger.Logger.Debug("Node %s: Received %d bytes, command type: %s", cmd.node.String(), dataReceived, ifc.commandType().String())
 			// Capture timing for parsing results and total bytes received from the server.
 			cmd.applyDetailedMetricsParsing(ifc, start, dataReceived)
 		} else {
@@ -3916,7 +3916,7 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 					cmd.conn.Close()
 				}
 
-				logger.Logger.Debug("Node " + cmd.node.String() + ": " + err.Error())
+				logger.Logger.Debug("Node %s: %s", cmd.node.String(), err.Error())
 
 				// retry only for non-streaming commands
 				if !cmd.oneShot {

--- a/connection.go
+++ b/connection.go
@@ -384,7 +384,7 @@ func (ctn *Connection) Close() {
 			}
 
 			if err := ctn.conn.Close(); err != nil {
-				logger.Logger.Warn(err.Error())
+				logger.Logger.Warn("%s", err.Error())
 			}
 			ctn.conn = nil
 

--- a/execute_command.go
+++ b/execute_command.go
@@ -80,7 +80,7 @@ func (cmd *executeCommand) parseResult(ifc command, conn *Connection) Error {
 		} else if rp.resultCode == types.UDF_BAD_RESPONSE {
 			cmd.record, _ = rp.parseRecord(cmd.key, false)
 			err := cmd.handleUdfError(rp.resultCode)
-			logger.Logger.Debug("UDF execution error: " + err.Error())
+			logger.Logger.Debug("UDF execution error: %s", err.Error())
 			return err
 		}
 

--- a/fips_complience_test.go
+++ b/fips_complience_test.go
@@ -27,6 +27,8 @@ var _ = Describe("FIPS Compliance", func() {
 	Describe("FIPS mode", func() {
 		BeforeEach(func() {
 			// Check if FIPS environment is configured
+			// This is only used when testing locally
+			// and user might have not set right env variables
 			godebug := os.Getenv("GODEBUG")
 			if godebug == "" || (!strings.Contains(godebug, "fips140=on") && !strings.Contains(godebug, "fips140=only")) {
 				Skip("FIPS test skipped: set GODEBUG=fips140=on or GODEBUG=fips140=only to run")

--- a/fips_complience_test.go
+++ b/fips_complience_test.go
@@ -1,0 +1,40 @@
+// Copyright 2014-2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aerospike_test
+
+import (
+	"crypto/fips140"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FIPS Compliance", func() {
+	Describe("FIPS mode", func() {
+		BeforeEach(func() {
+			// Check if FIPS environment is configured
+			godebug := os.Getenv("GODEBUG")
+			if godebug == "" || (!strings.Contains(godebug, "fips140=on") && !strings.Contains(godebug, "fips140=only")) {
+				Skip("FIPS test skipped: set GODEBUG=fips140=on or GODEBUG=fips140=only to run")
+			}
+		})
+
+		It("should be enabled when GODEBUG is set correctly", func() {
+			Expect(fips140.Enabled()).To(BeTrue(), "FIPS mode is not enabled (set GODEBUG=fips140=on or only)")
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aerospike/aerospike-client-go/v8
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aerospike/aerospike-client-go/v8
 
-go 1.24.0
+go 1.25.1
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.2

--- a/internal/lua/instance.go
+++ b/internal/lua/instance.go
@@ -46,12 +46,12 @@ func newInstance(params ...interface{}) interface{} {
 	registerLuaMapType(L)
 
 	if err := L.DoString(luaLib.LibStreamOps); err != nil {
-		logger.Logger.Error(err.Error())
+		logger.Logger.Error("%s", err.Error())
 		return nil
 	}
 
 	if err := L.DoString(luaLib.LibAerospike); err != nil {
-		logger.Logger.Error(err.Error())
+		logger.Logger.Error("%s", err.Error())
 		return nil
 	}
 

--- a/internal/lua/lua_aerospike.go
+++ b/internal/lua/lua_aerospike.go
@@ -53,11 +53,11 @@ func luaAerospikeLog(L *lua.LState) int {
 
 	switch level {
 	case 1:
-		logger.Logger.Warn(str)
+		logger.Logger.Warn("%s", str)
 	case 2:
-		logger.Logger.Info(str)
+		logger.Logger.Info("%s", str)
 	case 3, 4:
-		logger.Logger.Debug(str)
+		logger.Logger.Debug("%s", str)
 	}
 
 	return 0

--- a/node_validator.go
+++ b/node_validator.go
@@ -82,7 +82,7 @@ func (ndv *nodeValidator) validateNode(cluster *Cluster, host *Host) Error {
 		masterHostname := clusterNodes[0].host.Name
 		ip, ipnet, err := net.ParseCIDR(masterHostname + "/24")
 		if err != nil {
-			logger.Logger.Error(err.Error())
+			logger.Logger.Error("%s", err.Error())
 			return newError(types.NO_AVAILABLE_CONNECTIONS_TO_NODE, "Failed parsing hostname...")
 		}
 


### PR DESCRIPTION
Validated changes locally as per https://go.dev/doc/security/fips140.