### PR TITLE
CLIENT-3021 Statement.BinNames must be empty for QueryExecute

### DIFF
--- a/client.go
+++ b/client.go
@@ -1355,13 +1355,10 @@ func (clnt *Client) QueryExecute(policy *QueryPolicy,
 	statement *Statement,
 	ops ...*Operation,
 ) (*ExecuteTask, Error) {
-	if len(statement.BinNames) > 0 {
-		return nil, ErrNoBinNamesAllowedInQueryExecute.err()
-	}
-	taskId := statement.prepareTaskId()
-
 	policy = clnt.getUsableQueryPolicy(policy)
 	writePolicy = clnt.getUsableWritePolicy(writePolicy)
+
+	taskId := statement.prepareTaskId()
 
 	nodes := clnt.cluster.GetNodes()
 	if len(nodes) == 0 {

--- a/error.go
+++ b/error.go
@@ -378,7 +378,6 @@ var (
 	ErrNetTimeout                      = newConstError(types.TIMEOUT, "network timeout")
 	ErrUDFBadResponse                  = newConstError(types.UDF_BAD_RESPONSE, "invalid UDF return value")
 	ErrNoOperationsSpecified           = newConstError(types.INVALID_COMMAND, "no operations were passed to QueryExecute")
-	ErrNoBinNamesAllowedInQueryExecute = newConstError(types.INVALID_COMMAND, "`Statement.BinNames` must be empty for QueryExecute")
 	ErrFilteredOut                     = newConstError(types.FILTERED_OUT)
 	ErrPartitionScanQueryNotSupported  = newConstError(types.PARAMETER_ERROR, "partition Scans/Queries are not supported by all nodes in this cluster")
 	ErrScanTerminated                  = newConstError(types.SCAN_TERMINATED)

--- a/error.go
+++ b/error.go
@@ -378,6 +378,7 @@ var (
 	ErrNetTimeout                      = newConstError(types.TIMEOUT, "network timeout")
 	ErrUDFBadResponse                  = newConstError(types.UDF_BAD_RESPONSE, "invalid UDF return value")
 	ErrNoOperationsSpecified           = newConstError(types.INVALID_COMMAND, "no operations were passed to QueryExecute")
+	ErrNoBinNamesAllowedInQueryExecute = newConstError(types.INVALID_COMMAND, "`Statement.BinNames` must be empty for QueryExecute")
 	ErrFilteredOut                     = newConstError(types.FILTERED_OUT)
 	ErrPartitionScanQueryNotSupported  = newConstError(types.PARAMETER_ERROR, "partition Scans/Queries are not supported by all nodes in this cluster")
 	ErrScanTerminated                  = newConstError(types.SCAN_TERMINATED)

--- a/query_test.go
+++ b/query_test.go
@@ -542,6 +542,75 @@ var _ = gg.Describe("Query operations", func() {
 		}
 	})
 
+	gg.It("must not return server errors when QueryExecute is called with BinNames populated", func() {
+		// Create a statement with specific bin names
+		stm := as.NewStatement(ns, set, bin1.Name, bin3.Name, bin4.Name)
+		stm.SetFilter(as.NewEqualFilter(bin6.Name, 1))
+
+		bin8 := as.NewBin("Aerospike8", "BinNamesTest")
+
+		tsk, err := client.QueryExecute(queryPolicy, nil, stm, as.PutOp(bin8))
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		gm.Expect(tsk).ToNot(gm.BeNil())
+
+		completionErr := <-tsk.OnComplete()
+		gm.Expect(completionErr).To(gm.BeNil())
+
+		// Verify the operation was successful by reading back the records
+		// and checking that the new bin was added
+		verifyStm := as.NewStatement(ns, set)
+		verifyStm.SetFilter(as.NewEqualFilter(bin6.Name, 1))
+
+		recordset, err := client.Query(queryPolicy, verifyStm)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		foundRecords := 0
+		for res := range recordset.Results() {
+			gm.Expect(res.Err).ToNot(gm.HaveOccurred())
+			rec := res.Record
+			gm.Expect(rec).ToNot(gm.BeNil())
+
+			gm.Expect(rec.Bins[bin8.Name]).To(gm.Equal(bin8.Value.GetObject()))
+			foundRecords++
+		}
+
+		// Ensure we found the expected number of records
+		gm.Expect(foundRecords).To(gm.Equal(keyCount))
+	})
+
+	gg.It("must not return server errors when QueryExecute is called with BinNames in scan mode (no filter)", func() {
+		// Create a statement with specific bin names but NO filter (scan mode)
+		stm := as.NewStatement(ns, set, bin1.Name, bin2.Name, bin3.Name)
+
+		bin9 := as.NewBin("Aerospike9", "ScanBinNamesTest")
+
+		tsk, err := client.QueryExecute(queryPolicy, nil, stm, as.PutOp(bin9))
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		gm.Expect(tsk).ToNot(gm.BeNil())
+
+		completionErr := <-tsk.OnComplete()
+		gm.Expect(completionErr).To(gm.BeNil())
+
+		// Verify the operation was successful by scanning back all records
+		verifyStm := as.NewStatement(ns, set)
+
+		recordset, err := client.Query(queryPolicy, verifyStm)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		foundRecords := 0
+		for res := range recordset.Results() {
+			gm.Expect(res.Err).ToNot(gm.HaveOccurred())
+			rec := res.Record
+			gm.Expect(rec).ToNot(gm.BeNil())
+
+			gm.Expect(rec.Bins[bin9.Name]).To(gm.Equal(bin9.Value.GetObject()))
+			foundRecords++
+		}
+
+		// Ensure we found all records in the set
+		gm.Expect(foundRecords).To(gm.Equal(keyCount))
+	})
+
 	gg.It("must allow reusing the same statement for multiple QueryExecute calls without errors", func() {
 		stm := as.NewStatement(ns, set)
 		stm.SetFilter(as.NewEqualFilter(bin6.Name, 1))


### PR DESCRIPTION
Used java as base. More specifically the [execute](https://github.com/aerospike/aerospike-client-java/blob/aaf1f793886b5ff8852e3854f860aaed23bc0a02/client/src/com/aerospike/client/AerospikeClient.java#L4237) method on java side does not check and throw an exception if statement.binNames is not empty.


