### PR TITLE
CLIENT-2418 Skip orphan seeds that do not have peers when other seeds have peers

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -327,7 +327,7 @@ func (clstr *Cluster) tend() Error {
 
 			// Preventing duplicate entries.
 			if _peer.replaceNode != nil && !peers.containsNodeToRemove(_peer.replaceNode) {
-					peers.addNodesToRemove(_peer.replaceNode)
+				peers.addNodesToRemove(_peer.replaceNode)
 			}
 			return seq.Break
 		})
@@ -343,9 +343,6 @@ func (clstr *Cluster) tend() Error {
 	})
 
 	if peers.genChanged.Get() {
-		// Handle nodes changes determined from refreshes.
-		removeList := clstr.findNodesToRemove(peers)
-
 		// Remove nodes in a batch.
 		nodesToRemove := peers.getNodesToRemove()
 		for i := range nodesToRemove {
@@ -653,9 +650,8 @@ func (clstr *Cluster) addAlias(host *Host, node *Node) {
 	}
 }
 
-func (clstr *Cluster) findNodesToRemove(_peers *peers) []*Node {
-	refreshCount := _peers.refreshCount.Get()
-	removeList := []*Node{}
+func (clstr *Cluster) findNodesToRemove(peers *peers) {
+	refreshCount := peers.refreshCount.Get()
 
 	if clstr.clientPolicy.Load().SeedOnlyCluster {
 		// Don't remove any node even if its bad or inactive.
@@ -702,7 +698,7 @@ func (clstr *Cluster) findNodesToRemove(_peers *peers) []*Node {
 				}
 				// If node is orphan, it can be removed if it has no references and no peers.
 				if node.referenceCount.Get() == 0 && node.peersCount.Get() == 0 && node.isOrphan.Get() {
-					removeList = append(removeList, node)
+					peers.addNodesToRemove(node)
 				}
 			} else {
 				// Node not responding. Remove it.

--- a/cluster.go
+++ b/cluster.go
@@ -344,7 +344,7 @@ func (clstr *Cluster) tend() Error {
 
 	if peers.genChanged.Get() {
 		// Handle nodes changes determined from refreshes.
-		clstr.findNodesToRemove(peers)
+		removeList := clstr.findNodesToRemove(peers)
 
 		// Remove nodes in a batch.
 		nodesToRemove := peers.getNodesToRemove()
@@ -653,8 +653,9 @@ func (clstr *Cluster) addAlias(host *Host, node *Node) {
 	}
 }
 
-func (clstr *Cluster) findNodesToRemove(peers *peers) {
-	refreshCount := peers.refreshCount.Get()
+func (clstr *Cluster) findNodesToRemove(_peers *peers) []*Node {
+	refreshCount := _peers.refreshCount.Get()
+	removeList := []*Node{}
 
 	if clstr.clientPolicy.Load().SeedOnlyCluster {
 		// Don't remove any node even if its bad or inactive.
@@ -662,8 +663,11 @@ func (clstr *Cluster) findNodesToRemove(peers *peers) {
 	}
 
 	nodes := clstr.GetNodes()
-
+	var numberOfOrphans int64
 	for _, node := range nodes {
+		if node.isOrphan.Get() {
+			numberOfOrphans++
+		}
 		if !node.IsActive() {
 			// Inactive nodes must be removed.
 			if !peers.containsNodeToRemove(node) {
@@ -695,6 +699,10 @@ func (clstr *Cluster) findNodesToRemove(peers *peers) {
 					if !peers.containsNodeToRemove(node) {
 						peers.addNodesToRemove(node)
 					}
+				}
+				// If node is orphan, it can be removed if it has no references and no peers.
+				if node.referenceCount.Get() == 0 && node.peersCount.Get() == 0 && node.isOrphan.Get() {
+					removeList = append(removeList, node)
 				}
 			} else {
 				// Node not responding. Remove it.

--- a/node.go
+++ b/node.go
@@ -81,7 +81,8 @@ type Node struct {
 
 	active iatomic.Bool
 
-	version version.Version
+	version  version.Version
+	isOrphan iatomic.Bool
 }
 
 // NewNode initializes a server node with connection parameters.
@@ -191,7 +192,7 @@ func (nd *Node) Refresh(peers *peers) Error {
 
 	nd.failures.Set(0)
 	peers.refreshCount.IncrementAndGet()
-	nd.referenceCount.IncrementAndGet()
+	// nd.referenceCount.IncrementAndGet()
 	nd.stats.TendsSuccessful.IncrementAndGet()
 
 	if err = nd.refreshSessionToken(); err != nil {
@@ -334,10 +335,15 @@ func (nd *Node) refreshPeers(peers *peers) {
 		return
 	}
 
-	peers.appendPeers(peerParser.peers)
+	// If node has no peers, it is suspected to be orphan
+	// if !nd.isOrphan.Get() {
+	if len(peerParser.peers) > 0 {
+		peers.refreshCount.IncrementAndGet()
+		peers.appendPeers(peerParser.peers)
+	}
+
 	nd.peersGeneration.Set(int(peerParser.generation()))
 	nd.peersCount.Set(len(peers.peers()))
-	peers.refreshCount.IncrementAndGet()
 }
 
 func (nd *Node) refreshPartitions(peers *peers, partitions partitionMap, freshlyAdded bool) {

--- a/node.go
+++ b/node.go
@@ -192,7 +192,7 @@ func (nd *Node) Refresh(peers *peers) Error {
 
 	nd.failures.Set(0)
 	peers.refreshCount.IncrementAndGet()
-	// nd.referenceCount.IncrementAndGet()
+	nd.referenceCount.IncrementAndGet()
 	nd.stats.TendsSuccessful.IncrementAndGet()
 
 	if err = nd.refreshSessionToken(); err != nil {

--- a/peers.go
+++ b/peers.go
@@ -15,130 +15,81 @@
 package aerospike
 
 import (
-	"sync"
-
 	"github.com/aerospike/aerospike-client-go/v8/internal/atomic"
+	sm "github.com/aerospike/aerospike-client-go/v8/internal/atomic/map"
 )
 
 type peers struct {
-	_peers         map[string]*peer
-	_hosts         map[Host]struct{} // TODO: remove this since we are not using it
-	_nodes         map[string]*Node
-	_nodesToRemove []*Node
+	_peers         sm.Map[string, *peer]
+	_nodes         sm.Map[string, *Node]
+	_nodesToRemove sm.Map[string, *Node]
 	refreshCount   atomic.Int
 	genChanged     atomic.Bool
-
-	mutex sync.RWMutex
 }
 
 // newPeers creates a new peers object
 func newPeers(peerCapacity int, addCapacity int) *peers {
 	return &peers{
-		_peers:         make(map[string]*peer, peerCapacity),
-		_hosts:         make(map[Host]struct{}, addCapacity),
-		_nodes:         make(map[string]*Node, addCapacity),
-		_nodesToRemove: make([]*Node, 0),
+		_peers:         *sm.New[string, *peer](peerCapacity),
+		_nodes:         *sm.New[string, *Node](addCapacity),
+		_nodesToRemove: *sm.New[string, *Node](addCapacity),
 		genChanged:     *atomic.NewBool(true),
 	}
 }
 
-// todo: not used anywhere. Consider removing
-// hostExists checks if a host exists in the hosts map
-// TODO: remove this since we are not using it
-// hostExists checks if a host exists in the peers
-func (ps *peers) hostExists(host Host) bool {
-	ps.mutex.RLock()
-	defer ps.mutex.RUnlock()
-	_, exists := ps._hosts[host]
-	return exists
-}
-
-// TODO: remove this since we are not using it
-// addHost adds a host to the peers
-func (ps *peers) addHost(host Host) {
-	ps.mutex.Lock()
-	defer ps.mutex.Unlock()
-	ps._hosts[host] = struct{}{}
-}
-
 // addNode adds a node to the nodes map
-// addNode adds a node to the peers
 func (ps *peers) addNode(name string, node *Node) {
-	ps.mutex.Lock()
-	defer ps.mutex.Unlock()
-	ps._nodes[name] = node
+	ps._nodes.Set(name, node)
 }
 
-// nodeByName returns a node by name
 // nodeByName returns a node by name
 func (ps *peers) nodeByName(name string) *Node {
-	ps.mutex.RLock()
-	defer ps.mutex.RUnlock()
-	return ps._nodes[name]
+	return ps._nodes.Get(name)
 }
 
 // appendPeers adds a list of peers to the peers map
 // appendPears appends peers to the peers
 func (ps *peers) appendPeers(peers []*peer) {
-	ps.mutex.Lock()
-	defer ps.mutex.Unlock()
-
 	for _, peer := range peers {
-		ps._peers[peer.nodeName] = peer
+		ps._peers.Set(peer.nodeName, peer)
 	}
 }
 
 // peers returns a copy of peers for safe iteration
-// peers returns the peers
 func (ps *peers) peers() []*peer {
-	ps.mutex.RLock()
-	defer ps.mutex.RUnlock()
-
-	res := make([]*peer, 0, len(ps._peers))
-	for _, peer := range ps._peers {
-		res = append(res, peer)
-	}
-	return res
+	return sm.MapAllF(&ps._peers, func(m map[string]*peer) []*peer {
+		res := make([]*peer, 0, len(m))
+		for _, peer := range m {
+			res = append(res, peer)
+		}
+		return res
+	})
 }
 
 // nodes returns a copy of nodes for safe iteration
-// nodes returns the nodes
 func (ps *peers) nodes() map[string]*Node {
-	ps.mutex.RLock()
-	defer ps.mutex.RUnlock()
-	return ps._nodes
+	return ps._nodes.Clone()
 }
 
 // addNodesToRemove adds a node to the removal list
 func (ps *peers) addNodesToRemove(removeNode *Node) {
-	ps.mutex.Lock()
-	defer ps.mutex.Unlock()
-
-	ps._nodesToRemove = append(ps._nodesToRemove, removeNode)
+	ps._nodesToRemove.Set(removeNode.String(), removeNode)
 }
 
 // getNodesToRemove returns a copy of nodes to remove for safe iteration
 func (ps *peers) getNodesToRemove() []*Node {
-	ps.mutex.RLock()
-	defer ps.mutex.RUnlock()
-
-	// Return a copy to prevent race conditions
-	result := make([]*Node, len(ps._nodesToRemove))
-	copy(result, ps._nodesToRemove)
-	return result
+	return sm.MapAllF(&ps._nodesToRemove, func(m map[string]*Node) []*Node {
+		res := make([]*Node, 0, len(m))
+		for _, node := range m {
+			res = append(res, node)
+		}
+		return res
+	})
 }
 
 // containsNodeToRemove checks if a node is already marked for removal
 func (ps *peers) containsNodeToRemove(node *Node) bool {
-	ps.mutex.RLock()
-	defer ps.mutex.RUnlock()
-
-	for _, entry := range ps._nodesToRemove {
-		if entry.Equals(node) {
-			return true
-		}
-	}
-	return false
+	return ps._nodesToRemove.Exists(node.String())
 }
 
 // peer is a peer of a node

--- a/peers.go
+++ b/peers.go
@@ -22,7 +22,7 @@ import (
 
 type peers struct {
 	_peers         map[string]*peer
-	_hosts         map[Host]struct{}
+	_hosts         map[Host]struct{} // TODO: remove this since we are not using it
 	_nodes         map[string]*Node
 	_nodesToRemove []*Node
 	refreshCount   atomic.Int
@@ -44,6 +44,8 @@ func newPeers(peerCapacity int, addCapacity int) *peers {
 
 // todo: not used anywhere. Consider removing
 // hostExists checks if a host exists in the hosts map
+// TODO: remove this since we are not using it
+// hostExists checks if a host exists in the peers
 func (ps *peers) hostExists(host Host) bool {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
@@ -51,8 +53,8 @@ func (ps *peers) hostExists(host Host) bool {
 	return exists
 }
 
-// todo: not used anywhere. Consider removing
-// addHost adds a host to the hosts map
+// TODO: remove this since we are not using it
+// addHost adds a host to the peers
 func (ps *peers) addHost(host Host) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
@@ -60,12 +62,14 @@ func (ps *peers) addHost(host Host) {
 }
 
 // addNode adds a node to the nodes map
+// addNode adds a node to the peers
 func (ps *peers) addNode(name string, node *Node) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 	ps._nodes[name] = node
 }
 
+// nodeByName returns a node by name
 // nodeByName returns a node by name
 func (ps *peers) nodeByName(name string) *Node {
 	ps.mutex.RLock()
@@ -74,6 +78,7 @@ func (ps *peers) nodeByName(name string) *Node {
 }
 
 // appendPeers adds a list of peers to the peers map
+// appendPears appends peers to the peers
 func (ps *peers) appendPeers(peers []*peer) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
@@ -84,6 +89,7 @@ func (ps *peers) appendPeers(peers []*peer) {
 }
 
 // peers returns a copy of peers for safe iteration
+// peers returns the peers
 func (ps *peers) peers() []*peer {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
@@ -96,6 +102,7 @@ func (ps *peers) peers() []*peer {
 }
 
 // nodes returns a copy of nodes for safe iteration
+// nodes returns the nodes
 func (ps *peers) nodes() map[string]*Node {
 	ps.mutex.RLock()
 	defer ps.mutex.RUnlock()
@@ -134,6 +141,7 @@ func (ps *peers) containsNodeToRemove(node *Node) bool {
 	return false
 }
 
+// peer is a peer of a node
 type peer struct {
 	nodeName    string
 	tlsName     string


### PR DESCRIPTION
Changes have been validated in aerolab

**scenario 1:**
- Two cluster setup. Cluster one had one node and cluster 2 had three nodes. Expected output from 
```
al cluster create -c1 -n mycluster && al cluster create -n mycluster_2 -c 3 -f ~/aerolab-config/features.conf
```
**Driver output:** 3 

**scenario 2:**
- Two cluster setup. Cluster one had one node. Cluster two had one node.
```
al cluster destroy -n mycluster && al cluster destroy -n mycluster_2
```
**Driver output:** 1. The node used should be the first node in the list of hosts. In the example below `localhost:3100`

**test driver:**
```
func main() {
	asl.Logger.SetLevel(asl.DEBUG)
	cp := aero.NewClientPolicy()
	cp.UseServicesAlternate = true
	cli, _ := aero.NewClientWithPolicyAndHost(cp, aero.NewHost("localhost", 3100), aero.NewHost("localhost", 3103))
        fmt.Println(cli.GetNodes())
}
```