### PR TITLE
Revert module go version to 1.23

### DIFF
--- a/fips_compliance_test.go
+++ b/fips_compliance_test.go
@@ -1,3 +1,5 @@
+//go:build go1.24
+
 // Copyright 2014-2022 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aerospike/aerospike-client-go/v8
 
-go 1.25.1
+go 1.23.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.2


### PR DESCRIPTION
Although the `crypto/fips140` module was introduced with go 1.24, the client is not required to target go 1.24 or higher. The FIPS Compliance test can be conditioned using a build constraint.