### PR TITLE
fix unsafe behaviour in connection.go:errToAerospikeErr() 

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -121,7 +121,7 @@ func errToAerospikeErr(conn *Connection, err error) (aerr Error) {
 			if conn != nil && conn.node != nil {
 				conn.node.stats.ConnectionsTimeoutErrors.IncrementAndGet()
 			}
-			if errors.Is(terr, os.ErrDeadlineExceeded) {
+			if conn != nil && errors.Is(terr, os.ErrDeadlineExceeded) {
 				conn.salvageConnection = true
 			}
 			// If the connection is not salvageable, close it.


### PR DESCRIPTION
In `func errToAerospikeErr(conn *Connection, err error) (aerr Error)` the provided conn may be salvaged by modifying one of the fields if the error originates from a `net` Timout or DeadlineExceeded.  
However in `func newConnection(address string, timeout time.Duration) (*Connection, Error)` if the `net.DialTimeout()` call timeouts, the non-nil err branch calls `errToAerospikeErr(nil, err)` ; this then leads to a `SIGSEGV`.  

If you wanna reproduce just have a distant Aerospike cluster behind some kind of poor networking (Tailscale should do the trick) and connect to it using the go client.