### PR TITLE
CLIENT-3937 Fix typos in comments across multiple files

### DIFF
--- a/batch_command.go
+++ b/batch_command.go
@@ -58,7 +58,7 @@ func (cmd *batchCommand) setInDoubt(ifc batcher) {
 }
 
 func (cmd *batchCommand) inDoubt() {
-	// do nothing by defaut
+	// do nothing by default
 }
 
 func (cmd *batchCommand) prepareRetry(ifc command, isTimeout bool) bool {

--- a/batch_record.go
+++ b/batch_record.go
@@ -51,7 +51,7 @@ type BatchRecordIfc interface {
 	equals(BatchRecordIfc) bool
 }
 
-// BatchRecord encasulates the Batch key and record result.
+// BatchRecord encapsulates the Batch key and record result.
 type BatchRecord struct {
 	// Key.
 	Key *Key
@@ -67,7 +67,7 @@ type BatchRecord struct {
 	// Err encapsulates the possible error chain for this key
 	Err Error
 
-	// InDoubt signifies the possiblity that the write command may have completed even though an error
+	// InDoubt signifies the possibility that the write command may have completed even though an error
 	// occurred for this record. This may be the case when a client error occurs (like timeout)
 	// after the command was sent to the server.
 	InDoubt bool

--- a/bit_resize_flags.go
+++ b/bit_resize_flags.go
@@ -18,7 +18,7 @@ package aerospike
 type BitResizeFlags int
 
 const (
-	// BitResizeFlagsDefault specifies the defalt flag.
+	// BitResizeFlagsDefault specifies the default flag.
 	BitResizeFlagsDefault BitResizeFlags = 0
 
 	// BitResizeFlagsFromFront Adds/removes bytes from the beginning instead of the end.

--- a/cdt_bitwise_test.go
+++ b/cdt_bitwise_test.go
@@ -222,7 +222,7 @@ var _ = gg.Describe("CDT Bitwise Test", func() {
 					0xc1},
 				as.BitSetOp(putMode, cdtBinName, 1, 1, bit0),
 				as.BitSetOp(putMode, cdtBinName, 15, 1, bit0),
-				// SUM Offest Size
+				// SUM Offset Size
 				as.BitSetOp(putMode, cdtBinName, 16, 24, bits1),  //  Y    Y      Y
 				as.BitSetOp(putMode, cdtBinName, 40, 22, bits1),  //  N    Y      N
 				as.BitSetOp(putMode, cdtBinName, 73, 21, bits1),  //  N    N      N

--- a/cdt_list.go
+++ b/cdt_list.go
@@ -160,7 +160,7 @@ const (
 	ListReturnTypeInverted ListReturnType = 0x10000
 )
 
-// ListSortFlags detemines sort flags for CDT lists
+// ListSortFlags determines sort flags for CDT lists
 type ListSortFlags int
 
 const (
@@ -172,7 +172,7 @@ const (
 	ListSortFlagsDropDuplicates ListSortFlags = 2
 )
 
-// ListWriteFlags detemines write flags for CDT lists
+// ListWriteFlags determines write flags for CDT lists
 // type ListWriteFlags int
 
 const (

--- a/client_appengine_exclusions.go
+++ b/client_appengine_exclusions.go
@@ -67,7 +67,7 @@ func (clnt *Client) QueryAggregate(policy *QueryPolicy, statement *Statement, pa
 	inputChan := make(chan interface{}, 4096) // 4096 = number of partitions
 	istream := lualib.NewStream(luaInstance, inputChan)
 
-	// Output Channe;
+	// Output Channel;
 	outputChan := make(chan interface{})
 	ostream := lualib.NewStream(luaInstance, outputChan)
 

--- a/command.go
+++ b/command.go
@@ -1192,7 +1192,7 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 			cmd.dataOffset++
 		} else {
 			// Must write full header and namespace/set/bin names.
-			cmd.dataOffset += 12 // header(4) + ttl(4) + fielCount(2) + opCount(2) = 12
+			cmd.dataOffset += 12 // header(4) + ttl(4) + fieldCount(2) + opCount(2) = 12
 			cmd.dataOffset += len(key.namespace) + int(_FIELD_HEADER_SIZE)
 			cmd.dataOffset += len(key.setName) + int(_FIELD_HEADER_SIZE)
 			cmd.sizeTxnBatch(txn, ver, record.BatchRec().hasWrite)
@@ -1379,7 +1379,7 @@ func (cmd *baseCommand) setBatchOperateReadOffsets(
 			cmd.dataOffset++
 		} else {
 			// Must write full header and namespace/set/bin names.
-			cmd.dataOffset += 12 // header(4) + ttl(4) + fielCount(2) + opCount(2) = 12
+			cmd.dataOffset += 12 // header(4) + ttl(4) + fieldCount(2) + opCount(2) = 12
 			cmd.dataOffset += len(key.namespace) + int(_FIELD_HEADER_SIZE)
 			cmd.dataOffset += len(key.setName) + int(_FIELD_HEADER_SIZE)
 			cmd.sizeTxnBatch(txn, ver, record.BatchRec().hasWrite)
@@ -1544,7 +1544,7 @@ func (cmd *baseCommand) setBatchOperateOffsets(
 			cmd.dataOffset++
 		} else {
 			// Must write full header and namespace/set/bin names.
-			cmd.dataOffset += 12 // header(4) + ttl(4) + fielCount(2) + opCount(2) = 12
+			cmd.dataOffset += 12 // header(4) + ttl(4) + fieldCount(2) + opCount(2) = 12
 			cmd.dataOffset += len(key.namespace) + int(_FIELD_HEADER_SIZE)
 			cmd.dataOffset += len(key.setName) + int(_FIELD_HEADER_SIZE)
 			cmd.sizeTxnBatch(txn, ver, attr.hasWrite)

--- a/config.go
+++ b/config.go
@@ -450,7 +450,7 @@ func (dc *DynConfig) watchConfig(interval time.Duration) {
 	// This allows the config to be updated dynamically without restarting the client.
 	dc.lock.RLock()
 	var mergedConfigInterval time.Duration
-	// Handle the condition where dynamic config is eneabled but config was not loaded becuase
+	// Handle the condition where dynamic config is enabled but config was not loaded because
 	// the file could not be found or the url is not valid. In that case we will use the interval passed
 	// in or use the default interval of 1 second.
 	if dc.config == nil {

--- a/docs/aerospike.md
+++ b/docs/aerospike.md
@@ -72,7 +72,7 @@ Example:
   client, err := as.NewClient("127.0.0.1", 3000)
 ```
 
-For detals, see [Client Class](client.md).
+For details, see [Client Class](client.md).
 
 <!--
 ################################################################################

--- a/expression.go
+++ b/expression.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ExpressionArgument is used for passing arguments to filter expressions.
-// The accptable arguments are:
+// The acceptable arguments are:
 // Value, ExpressionFilter, []*CDTContext
 type ExpressionArgument interface {
 	pack(BufferEx) (int, Error)

--- a/query_policy.go
+++ b/query_policy.go
@@ -30,7 +30,7 @@ type QueryPolicy struct {
 	// Default: LONG
 	ExpectedDuration QueryDuration
 
-	// ShortQuery determines wether query expected to return less than 100 records.
+	// ShortQuery determines whether query expected to return less than 100 records.
 	// If true, the server will optimize the query for a small record set.
 	// This field is ignored for aggregation queries, background queries
 	// and server versions 6.0+.

--- a/role.go
+++ b/role.go
@@ -41,13 +41,13 @@ const (
 	// SysAdmin allows to manage indexes, user defined functions and server configuration.
 	SysAdmin privilegeCode = "sys-admin"
 
-	// DataAdmin allows to manage indicies and user defined functions.
+	// DataAdmin allows to manage indices and user defined functions.
 	DataAdmin privilegeCode = "data-admin"
 
 	// UDFAdmin allows to manage user defined functions.
 	UDFAdmin privilegeCode = "udf-admin"
 
-	// SIndexAdmin allows to manage indicies.
+	// SIndexAdmin allows to manage indices.
 	SIndexAdmin privilegeCode = "sindex-admin"
 
 	// ReadWriteUDF allows read, write and UDF transactions with the database.

--- a/security_test.go
+++ b/security_test.go
@@ -74,7 +74,7 @@ var _ = gg.Describe("Security tests", func() {
 			err = client.GrantPrivileges(nil, "role-read-test-test", []as.Privilege{{Code: as.ReadWrite, Namespace: ns, SetName: "bar"}, {Code: as.ReadWriteUDF, Namespace: ns, SetName: "test"}})
 			gm.Expect(err).ToNot(gm.HaveOccurred())
 
-			// Wait until servers syncronize
+			// Wait until servers synchronize
 			time.Sleep(1 * time.Second)
 
 			// Revoke privileges from the roles
@@ -90,7 +90,7 @@ var _ = gg.Describe("Security tests", func() {
 			err = client.DropRole(nil, "dummy-role")
 			gm.Expect(err).ToNot(gm.HaveOccurred())
 
-			// Wait until servers syncronize
+			// Wait until servers synchronize
 			time.Sleep(3 * time.Second)
 
 			roles, err := client.QueryRoles(nil)

--- a/types/pool.go
+++ b/types/pool.go
@@ -26,7 +26,7 @@ type Pool struct {
 	New func(params ...interface{}) interface{}
 	// IsUsable checks if the object polled from the pool is still fresh and usable
 	IsUsable func(obj interface{}, params ...interface{}) bool
-	// CanReturn checkes if the object is eligible to go back to the pool
+	// CanReturn checks if the object is eligible to go back to the pool
 	CanReturn func(obj interface{}) bool
 	// Finalize will be called when an object is not eligible to go back to the pool.
 	// Usable to close connections, file handles, ...


### PR DESCRIPTION
The PR corrects typos in comments and docs.