### PR TITLE
CLIENT-3925 - Avoid sending previous errors when cluster is complete

### DIFF
--- a/scan_executor.go
+++ b/scan_executor.go
@@ -49,9 +49,9 @@ func (clnt *Client) scanPartitions(policy *ScanPolicy, tracker *partitionTracker
 		}
 
 		if done, err := tracker.isClusterComplete(clnt.Cluster(), &policy.BasePolicy); !recordset.IsActive() || done || err != nil {
-			errs = chainErrors(err, errs)
 			// Scan is complete.
-			if errs != nil {
+			if err != nil {
+				errs = chainErrors(err, errs)
 				tracker.partitionError()
 				recordset.sendError(errs)
 			}


### PR DESCRIPTION
ABS resilience tests revealed an issue where the client sends previously aggregated errors even after a scan successfully completes.

This PR implements a fix to resolve the issue.