### PR TITLE
CLIENT-3936 Make RegisterUDF backward compatible with older Aerospike server versions

### DIFF
--- a/client.go
+++ b/client.go
@@ -1190,7 +1190,7 @@ func (clnt *Client) RegisterUDF(policy *WritePolicy, udfBody []byte, serverPath 
 	}
 
 	response := responseMap[strCmd.String()]
-	if strings.EqualFold(response, "ok") {
+	if strings.EqualFold(response, "ok") || response == "" {
 		return NewRegisterTask(clnt.cluster, serverPath), nil
 	}
 


### PR DESCRIPTION
This PR resolves a compatibility issue discovered during ABS regression-compatibility testing. Go client v7 introduced a breaking change to the `RegisterUDF` method, preventing it from working correctly with Aerospike server versions v5.7-v6.1.