### PR TITLE
CLIENT-4016 BatchDelete panics in goroutine when namespace does not exist

### DIFF
--- a/batch_node_list.go
+++ b/batch_node_list.go
@@ -51,9 +51,9 @@ func newBatchNodeList(cluster *Cluster, policy *BatchPolicy, keys []*Key, record
 		if err != nil {
 			if len(records) > 0 {
 				records[i].Err = chainErrors(err, records[i].Err)
-			} else {
-				errs = chainErrors(err, errs)
+				records[i].ResultCode = err.resultCode()
 			}
+			errs = chainErrors(err, errs)
 			// return nil, err
 		}
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -442,6 +442,33 @@ var _ = gg.Describe("Aerospike", func() {
 				gm.Expect(err.Matches(types.INVALID_NAMESPACE)).To(gm.BeTrue())
 			})
 
+			gg.It("Should not panic on BatchDelete with non-existent namespace", func() {
+				// This test validates the fix for nil cmd.node panic in retry logic
+				var keys []*as.Key
+				for i := 0; i < 10; i++ {
+					key, _ := as.NewKey("non_existent_namespace", "non_existent_set", i)
+					keys = append(keys, key)
+				}
+
+				bp := as.NewBatchPolicy()
+				bp.MaxRetries = 2 // Ensure retry logic is exercised
+				bdp := as.NewBatchDeletePolicy()
+
+				// This should return an error but not panic
+				records, err := client.BatchDelete(bp, bdp, keys)
+				gm.Expect(err).To(gm.HaveOccurred())
+				gm.Expect(err.Matches(types.INVALID_NAMESPACE)).To(gm.BeTrue())
+
+				// Also check individual record errors
+				gm.Expect(records).NotTo(gm.BeNil())
+				gm.Expect(len(records)).To(gm.Equal(len(keys)))
+				for _, record := range records {
+					gm.Expect(record.Err).To(gm.HaveOccurred())
+					gm.Expect(record.Err.Matches(types.INVALID_NAMESPACE)).To(gm.BeTrue())
+					gm.Expect(record.ResultCode).To(gm.Equal(types.INVALID_NAMESPACE))
+				}
+			})
+
 			gg.It("Overall command error should be reflected in API call error and not BatchRecord error", func() {
 				var batchRecords []as.BatchRecordIfc
 				key, _ := as.NewKey(*namespace, set, 0)

--- a/client.go
+++ b/client.go
@@ -944,7 +944,7 @@ func (clnt *Client) BatchDelete(policy *BatchPolicy, deletePolicy *BatchDeletePo
 
 	batchNodes, err := newBatchNodeList(clnt.cluster, policy, keys, records, true)
 	if err != nil {
-		return nil, err
+		return records, err
 	}
 
 	cmd := newBatchCommandDelete(clnt, nil, policy, deletePolicy, keys, records, attr)
@@ -1011,7 +1011,7 @@ func (clnt *Client) BatchExecute(policy *BatchPolicy, udfPolicy *BatchUDFPolicy,
 
 	batchNodes, err := newBatchNodeList(clnt.cluster, policy, keys, records, attr.hasWrite)
 	if err != nil {
-		return nil, err
+		return records, err
 	}
 
 	cmd := newBatchCommandUDF(clnt, nil, policy, udfPolicy, keys, packageName, functionName, args, records, attr)

--- a/command.go
+++ b/command.go
@@ -3708,25 +3708,29 @@ func (cmd *baseCommand) executeAt(ifc command, policy *BasePolicy, deadline time
 		}
 
 		if notFirstIteration {
-			applyTransactionRetryMetrics(cmd.node)
+			if cmd.node != nil {
+				applyTransactionRetryMetrics(cmd.node)
+			}
 
 			if !ifc.prepareRetry(ifc, isClientTimeout || (err != nil && err.Matches(types.SERVER_NOT_AVAILABLE))) {
 				if bc, ok := ifc.(batcher); ok {
 					// Batch may be retried in separate commands.
-					alreadyRetried, err := bc.retryBatch(bc, cmd.node.cluster, cmd.commandSentCounter)
-					if alreadyRetried {
-						// Batch was retried in separate subcommands. Complete this command.
-						applyTransactionMetrics(cmd.node, ifc.commandType(), transStart)
-						if err != nil {
-							return chainErrors(err, errChain).iter(cmd.commandSentCounter).setNode(cmd.node).setInDoubt(ifc.isRead(), cmd.commandSentCounter)
+					if cmd.node != nil {
+						alreadyRetried, err := bc.retryBatch(bc, cmd.node.cluster, cmd.commandSentCounter)
+						if alreadyRetried {
+							// Batch was retried in separate subcommands. Complete this command.
+							applyTransactionMetrics(cmd.node, ifc.commandType(), transStart)
+							if err != nil {
+								return chainErrors(err, errChain).iter(cmd.commandSentCounter).setNode(cmd.node).setInDoubt(ifc.isRead(), cmd.commandSentCounter)
+							}
+							return nil
 						}
-						return nil
-					}
 
-					// chain the errors and retry
-					if err != nil {
-						errChain = chainErrors(err, errChain).iter(cmd.commandSentCounter).setNode(cmd.node).setInDoubt(ifc.isRead(), cmd.commandSentCounter)
-						continue
+						// chain the errors and retry
+						if err != nil {
+							errChain = chainErrors(err, errChain).iter(cmd.commandSentCounter).setNode(cmd.node).setInDoubt(ifc.isRead(), cmd.commandSentCounter)
+							continue
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Added logic to handle the case if node is nil for cases where we try to perform BatchDelete on record for namespace that does not exist.
- Will properly propagate error up the chain. This might be controversial change in that if there are errors on BatchDelete we are no longer returning nil but records. I would say border line api change. Not changing the API per se but the api behaves slightly differently. On the flip side this change does fall in line how Java functions.

Will have to back port to v6(confirmed exists) and v7.
