### PR TITLE
CLIENT-4083:Added sleepMutliplier to be part of dynamic config

### DIFF
--- a/batch_policy.go
+++ b/batch_policy.go
@@ -220,6 +220,13 @@ func (p *BatchPolicy) mapDynamic(dynConfig *DynConfig) *BatchPolicy {
 				logger.Logger.Debug("SleepBetweenRetries set to %s", configValue.String())
 			}
 		}
+		if currentConfig.Dynamic.BatchRead.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.BatchRead.SleepMultiplier
+			p.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Debug("SleepMultiplier set to %f", configValue)
+			}
+		}
 		if currentConfig.Dynamic.BatchRead.AllowInline != nil {
 			configValue := *currentConfig.Dynamic.BatchRead.AllowInline
 			p.AllowInline = configValue

--- a/batch_read_policy_config_test.go
+++ b/batch_read_policy_config_test.go
@@ -50,6 +50,10 @@ var _ = gg.Describe("ApplyConfigToBatchReadPolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -111,6 +115,10 @@ var _ = gg.Describe("ApplyConfigToBatchReadPolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -140,6 +148,7 @@ var _ = gg.Describe("ApplyConfigToBatchReadPolicy", func() {
 			gm.Expect(batchPolicy.ReadModeAP).To(gm.Equal(ReadModeAPOne))
 			gm.Expect(batchPolicy.ReadModeSC).To(gm.Equal(ReadModeSCSession))
 			gm.Expect(batchPolicy.ReadTouchTTLPercent).To(gm.Equal(int32(0)))
+			gm.Expect(batchPolicy.SleepMultiplier).To(gm.Equal(1.0))
 
 			// Apply configuration to BatchPolicy.
 			batchPolicy = config.client.dynDefaultBatchPolicy.Load()
@@ -150,6 +159,7 @@ var _ = gg.Describe("ApplyConfigToBatchReadPolicy", func() {
 			gm.Expect(batchPolicy.TotalTimeout).To(gm.Equal(15 * time.Millisecond))
 			gm.Expect(batchPolicy.SocketTimeout).To(gm.Equal(3 * time.Millisecond))
 			gm.Expect(batchPolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(batchPolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(batchPolicy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(batchPolicy.ReplicaPolicy).To(gm.Equal(SEQUENCE))
 			gm.Expect(batchPolicy.SendKey).To(gm.BeFalse())
@@ -168,6 +178,7 @@ var _ = gg.Describe("ApplyConfigToBatchReadPolicy", func() {
 			gm.Expect(updatedWritePolicy.TotalTimeout).To(gm.Equal(15 * time.Millisecond))
 			gm.Expect(updatedWritePolicy.SocketTimeout).To(gm.Equal(3 * time.Millisecond))
 			gm.Expect(updatedWritePolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(updatedWritePolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(updatedWritePolicy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(updatedWritePolicy.SendKey).To(gm.BeFalse())
 		})

--- a/batch_write_policy_config_test.go
+++ b/batch_write_policy_config_test.go
@@ -42,6 +42,10 @@ var _ = gg.Describe("ApplyConfigToBatchWritePolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -119,6 +123,10 @@ var _ = gg.Describe("ApplyConfigToBatchWritePolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -169,6 +177,10 @@ var _ = gg.Describe("ApplyConfigToBatchWritePolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -202,6 +214,7 @@ var _ = gg.Describe("ApplyConfigToBatchWritePolicy", func() {
 			gm.Expect(batchPolicy.SocketTimeout).To(gm.Equal(30 * time.Second))
 			gm.Expect(batchPolicy.MaxRetries).To(gm.Equal(2))
 			gm.Expect(batchPolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(batchPolicy.SleepMultiplier).To(gm.Equal(1.0))
 			gm.Expect(batchPolicy.ReplicaPolicy).To(gm.Equal(SEQUENCE))
 			gm.Expect(batchPolicy.SendKey).To(gm.BeFalse())
 			gm.Expect(batchPolicy.UseCompression).To(gm.BeFalse())
@@ -216,6 +229,7 @@ var _ = gg.Describe("ApplyConfigToBatchWritePolicy", func() {
 			gm.Expect(batchPolicy.TotalTimeout).To(gm.Equal(15 * time.Millisecond))
 			gm.Expect(batchPolicy.SocketTimeout).To(gm.Equal(3 * time.Millisecond))
 			gm.Expect(batchPolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(batchPolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(batchPolicy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(batchPolicy.ReplicaPolicy).To(gm.Equal(SEQUENCE))
 			gm.Expect(batchPolicy.SendKey).To(gm.BeFalse())
@@ -233,6 +247,7 @@ var _ = gg.Describe("ApplyConfigToBatchWritePolicy", func() {
 			gm.Expect(updatedWritePolicy.TotalTimeout).To(gm.Equal(15 * time.Millisecond))
 			gm.Expect(updatedWritePolicy.SocketTimeout).To(gm.Equal(3 * time.Millisecond))
 			gm.Expect(updatedWritePolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(updatedWritePolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(updatedWritePolicy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(updatedWritePolicy.SendKey).To(gm.BeTrue())
 		})

--- a/config/dynconfig.go
+++ b/config/dynconfig.go
@@ -86,6 +86,7 @@ type Read struct {
 	ReadModeSc          *ReadModeSc `yaml:"read_mode_sc"`
 	Replica             *Replica    `yaml:"replica"`
 	SleepBetweenRetries *int        `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64    `yaml:sleep_multiplier`
 	SocketTimeout       *int        `yaml:"socket_timeout"`
 	TotalTimeout        *int        `yaml:"total_timeout"`
 	MaxRetries          *int        `yaml:"max_retries"`
@@ -96,6 +97,7 @@ type Write struct {
 	Replica             *Replica `yaml:"replica"`
 	SendKey             *bool    `yaml:"send_key"`
 	SleepBetweenRetries *int     `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64 `yaml:sleep_multiplier`
 	SocketTimeout       *int     `yaml:"socket_timeout"`
 	TotalTimeout        *int     `yaml:"total_timeout"`
 	MaxRetries          *int     `yaml:"max_retries"`
@@ -106,6 +108,7 @@ type Write struct {
 type Query struct {
 	Replica             *Replica       `yaml:"replica"`
 	SleepBetweenRetries *int           `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64       `yaml:sleep_multiplier`
 	SocketTimeout       *int           `yaml:"socket_timeout"`
 	TotalTimeout        *int           `yaml:"total_timeout"`
 	MaxRetries          *int           `yaml:"max_retries"`
@@ -118,6 +121,7 @@ type Query struct {
 type Scan struct {
 	Replica             *Replica `yaml:"replica"`
 	SleepBetweenRetries *int     `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64 `yaml:sleep_multiplier`
 	SocketTimeout       *int     `yaml:"socket_timeout"`
 	TimeoutDelay        *int     `yaml:"timeout_delay"`
 	TotalTimeout        *int     `yaml:"total_timeout"`
@@ -130,6 +134,7 @@ type BatchRead struct {
 	ReadModeSc          *ReadModeSc `yaml:"read_mode_sc"`
 	Replica             *Replica    `yaml:"replica"`
 	SleepBetweenRetries *int        `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64    `yaml:sleep_multiplier`
 	SocketTimeout       *int        `yaml:"socket_timeout"`
 	TotalTimeout        *int        `yaml:"total_timeout"`
 	MaxRetries          *int        `yaml:"max_retries"`
@@ -143,6 +148,7 @@ type BatchRead struct {
 type BatchWrite struct {
 	Replica             *Replica `yaml:"replica"`
 	SleepBetweenRetries *int     `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64 `yaml:sleep_multiplier`
 	SocketTimeout       *int     `yaml:"socket_timeout"`
 	TotalTimeout        *int     `yaml:"total_timeout"`
 	MaxRetries          *int     `yaml:"max_retries"`
@@ -170,6 +176,7 @@ type TxnRoll struct {
 	ReadModeSc          *ReadModeSc `yaml:"read_mode_sc"`
 	Replica             *Replica    `yaml:"replica"`
 	SleepBetweenRetries *int        `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64    `yaml:sleep_multiplier`
 	SocketTimeout       *int        `yaml:"socket_timeout"`
 	TotalTimeout        *int        `yaml:"total_timeout"`
 	MaxRetries          *int        `yaml:"max_retries"`
@@ -184,6 +191,7 @@ type TxnVerify struct {
 	ReadModeSc          *ReadModeSc `yaml:"read_mode_sc"`
 	Replica             *Replica    `yaml:"replica"`
 	SleepBetweenRetries *int        `yaml:"sleep_between_retries"`
+	SleepMultiplier     *float64    `yaml:sleep_multiplier`
 	SocketTimeout       *int        `yaml:"socket_timeout"`
 	TotalTimeout        *int        `yaml:"total_timeout"`
 	MaxRetries          *int        `yaml:"max_retries"`

--- a/partition_tracker.go
+++ b/partition_tracker.go
@@ -36,6 +36,7 @@ type partitionTracker struct {
 	recordCount         *atmc.Int
 	maxRecords          int64
 	sleepBetweenRetries time.Duration
+	sleepMultiplier     float64
 	socketTimeout       time.Duration
 	totalTimeout        time.Duration
 	iteration           int //= 1
@@ -137,6 +138,7 @@ func newPartitionTracker(policy *MultiPolicy, filter *PartitionFilter, nodes []*
 
 func (pt *partitionTracker) init(policy *MultiPolicy) {
 	pt.sleepBetweenRetries = policy.SleepBetweenRetries
+	pt.sleepMultiplier = policy.SleepMultiplier
 	pt.socketTimeout = policy.SocketTimeout
 	pt.totalTimeout = policy.TotalTimeout
 
@@ -403,7 +405,9 @@ func (pt *partitionTracker) isComplete(hasPartitionQuery bool, policy *BasePolic
 	if pt.maxRecords > 0 {
 		pt.maxRecords -= recordCount
 	}
-
+	if pt.sleepMultiplier > 1 {
+		pt.sleepBetweenRetries = time.Duration(float64(pt.sleepBetweenRetries) * pt.sleepMultiplier)
+	}
 	pt.iteration++
 	return false, nil
 }

--- a/policy.go
+++ b/policy.go
@@ -293,6 +293,13 @@ func (bp *BasePolicy) mapDynamic(dynConfig *DynConfig) *BasePolicy {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
 			}
 		}
+		if currentConfig.Dynamic.Read.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.Read.SleepMultiplier
+			bp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
+			}
+		}
 		if currentConfig.Dynamic.Read.Replica != nil {
 			configValue := mapReplicaToReplicaPolicy(*currentConfig.Dynamic.Read.Replica)
 			bp.ReplicaPolicy = configValue
@@ -346,6 +353,13 @@ func (bp *BasePolicy) mapDynamicBatchWrite(dynConfig *DynConfig) *BasePolicy {
 			bp.SleepBetweenRetries = configValue
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
+			}
+		}
+		if currentConfig.Dynamic.BatchWrite.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.BatchWrite.SleepMultiplier
+			bp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
 			}
 		}
 		if currentConfig.Dynamic.BatchWrite.Replica != nil {
@@ -415,6 +429,13 @@ func (bp *BasePolicy) mapDynamicBatchRead(dynConfig *DynConfig) *BasePolicy {
 			bp.SleepBetweenRetries = configValue
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
+			}
+		}
+		if currentConfig.Dynamic.BatchRead.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.BatchRead.SleepMultiplier
+			bp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
 			}
 		}
 		if currentConfig.Dynamic.BatchRead.Replica != nil {

--- a/policy_config_test.go
+++ b/policy_config_test.go
@@ -58,6 +58,10 @@ var _ = gg.Describe("ApplyConfigToBasePolicy", func() {
 								d := 2
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							Replica: func() *dynconfig.Replica {
 								d := dynconfig.PREFER_RACK
 								return &d
@@ -81,7 +85,7 @@ var _ = gg.Describe("ApplyConfigToBasePolicy", func() {
 			gm.Expect(policy.SendKey).To(gm.BeFalse())
 			gm.Expect(policy.ReplicaPolicy).To(gm.Equal(SEQUENCE))
 			gm.Expect(policy.UseCompression).To(gm.BeFalse())
-
+			gm.Expect(policy.SleepMultiplier).To(gm.Equal(1.0))
 			// Apply the configuration.
 			updatedPolicy := policy.patchDynamic(config)
 
@@ -96,6 +100,7 @@ var _ = gg.Describe("ApplyConfigToBasePolicy", func() {
 			gm.Expect(updatedPolicy.SendKey).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.UseCompression).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.ReplicaPolicy).To(gm.Equal(PREFER_RACK))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(1.5))
 		})
 	})
 

--- a/query_policy.go
+++ b/query_policy.go
@@ -130,6 +130,13 @@ func (qp *QueryPolicy) mapDynamic(dynConfig *DynConfig) *QueryPolicy {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
 			}
 		}
+		if currentConfig.Dynamic.Query.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.Query.SleepMultiplier
+			qp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
+			}
+		}
 		if currentConfig.Dynamic.Query.Replica != nil {
 			configValue := mapReplicaToReplicaPolicy(*currentConfig.Dynamic.Query.Replica)
 			qp.ReplicaPolicy = configValue

--- a/query_policy_config_test.go
+++ b/query_policy_config_test.go
@@ -50,6 +50,10 @@ var _ = gg.Describe("ApplyConfigToQueryPolicy", func() {
 								d := 2
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.4
+								return &d
+							}(),
 							Replica: func() *dynconfig.Replica {
 								d := dynconfig.PREFER_RACK
 								return &d
@@ -80,7 +84,7 @@ var _ = gg.Describe("ApplyConfigToQueryPolicy", func() {
 			// SocketTimeout is in seconds.
 			gm.Expect(policy.SocketTimeout).To(gm.Equal(30 * time.Second))
 			gm.Expect(policy.MaxRetries).To(gm.Equal(5))
-			gm.Expect(policy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(policy.SleepMultiplier).To(gm.Equal(1.0))
 			gm.Expect(policy.SendKey).To(gm.BeFalse())
 			gm.Expect(policy.ReplicaPolicy).To(gm.Equal(SEQUENCE))
 			gm.Expect(policy.UseCompression).To(gm.BeFalse())
@@ -98,6 +102,7 @@ var _ = gg.Describe("ApplyConfigToQueryPolicy", func() {
 			// Note: Some tests change MaxRetries; full config changes it to 3.
 			gm.Expect(updatedPolicy.MaxRetries).To(gm.Equal(3))
 			gm.Expect(updatedPolicy.SleepBetweenRetries).To(gm.Equal(2 * time.Millisecond))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(1.4))
 			gm.Expect(updatedPolicy.SendKey).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.UseCompression).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.ReplicaPolicy).To(gm.Equal(PREFER_RACK))
@@ -127,6 +132,10 @@ var _ = gg.Describe("ApplyConfigToQueryPolicy", func() {
 								d := 2
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							Replica: func() *dynconfig.Replica {
 								r := dynconfig.PREFER_RACK
 								return &r
@@ -145,6 +154,7 @@ var _ = gg.Describe("ApplyConfigToQueryPolicy", func() {
 			gm.Expect(policy.SocketTimeout).To(gm.Equal(30 * time.Second))
 			gm.Expect(policy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(policy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(policy.SleepMultiplier).To(gm.Equal(1.0))
 			gm.Expect(policy.SendKey).To(gm.BeFalse())
 			gm.Expect(policy.ReplicaPolicy).To(gm.Equal(SEQUENCE))
 			gm.Expect(policy.UseCompression).To(gm.BeFalse())
@@ -160,6 +170,7 @@ var _ = gg.Describe("ApplyConfigToQueryPolicy", func() {
 			// MaxRetries should remain unchanged (default = 5) since it was not set.
 			gm.Expect(updatedPolicy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(updatedPolicy.SleepBetweenRetries).To(gm.Equal(2 * time.Millisecond))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(updatedPolicy.SendKey).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.UseCompression).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.ReplicaPolicy).To(gm.Equal(PREFER_RACK))

--- a/scan_policy.go
+++ b/scan_policy.go
@@ -122,6 +122,13 @@ func (sp *ScanPolicy) mapDynamic(dynConfig *DynConfig) *ScanPolicy {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
 			}
 		}
+		if currentConfig.Dynamic.Scan.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.Scan.SleepMultiplier
+			sp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
+			}
+		}
 		if currentConfig.Dynamic.Scan.Replica != nil {
 			configValue := mapReplicaToReplicaPolicy(*currentConfig.Dynamic.Scan.Replica)
 			sp.ReplicaPolicy = configValue

--- a/scan_policy_config_test.go
+++ b/scan_policy_config_test.go
@@ -115,6 +115,7 @@ var _ = gg.Describe("ApplyConfigToScanPolicy", func() {
 							}(),
 							MaxRetries:         func() *int { r := 3; return &r }(),
 							MaxConcurrentNodes: func() *int { r := 5; return &r }(),
+							SleepMultiplier:    func() *float64 { d := 2.0; return &d }(),
 						},
 					},
 				},
@@ -144,6 +145,7 @@ var _ = gg.Describe("ApplyConfigToScanPolicy", func() {
 			gm.Expect(updatedPolicy.TotalTimeout).To(gm.Equal(5000 * time.Millisecond))
 			gm.Expect(updatedPolicy.MaxRetries).To(gm.Equal(3))
 			gm.Expect(updatedPolicy.SleepBetweenRetries).To(gm.Equal(2 * time.Millisecond))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(2.0))
 			// Even if only select fields are configured, SendKey gets overridden.
 			gm.Expect(updatedPolicy.SendKey).To(gm.BeFalse())
 			gm.Expect(updatedPolicy.ReplicaPolicy).To(gm.Equal(SEQUENCE))

--- a/txn_monitor.go
+++ b/txn_monitor.go
@@ -160,6 +160,7 @@ func (tm *TxnMonitor) copyTimeoutPolicy(policy *BasePolicy) *WritePolicy {
 	wp.TimeoutDelay = policy.TimeoutDelay
 	wp.MaxRetries = policy.MaxRetries
 	wp.SleepBetweenRetries = policy.SleepBetweenRetries
+	wp.SleepMultiplier = policy.SleepMultiplier
 	wp.UseCompression = policy.UseCompression
 	wp.RespondPerEachOp = true
 

--- a/txn_roll_policy.go
+++ b/txn_roll_policy.go
@@ -34,6 +34,7 @@ func NewTxnRollPolicy() *TxnRollPolicy {
 	mp.SocketTimeout = 3 * time.Second
 	mp.TotalTimeout = 10 * time.Second
 	mp.SleepBetweenRetries = 1 * time.Second
+	mp.SleepMultiplier = 1.0
 
 	return &TxnRollPolicy{
 		BatchPolicy: mp,
@@ -108,6 +109,13 @@ func (trp *TxnRollPolicy) mapDynamic(dynConfig *DynConfig) *TxnRollPolicy {
 			trp.SleepBetweenRetries = configValue
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
+			}
+		}
+		if currentConfig.Dynamic.TxnRoll.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.TxnRoll.SleepMultiplier
+			trp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
 			}
 		}
 		if currentConfig.Dynamic.TxnRoll.SocketTimeout != nil {

--- a/txn_roll_policy_config_test.go
+++ b/txn_roll_policy_config_test.go
@@ -49,6 +49,10 @@ var _ = gg.Describe("ApplyConfigToTxnRollPolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -87,6 +91,7 @@ var _ = gg.Describe("ApplyConfigToTxnRollPolicy", func() {
 			gm.Expect(policy.ReadModeSC).To(gm.Equal(ReadModeSCSession))
 			gm.Expect(policy.ReplicaPolicy).To(gm.Equal(MASTER))
 			gm.Expect(policy.SleepBetweenRetries).To(gm.Equal(1 * time.Second))
+			gm.Expect(policy.SleepMultiplier).To(gm.Equal(1.0))
 			gm.Expect(policy.SocketTimeout).To(gm.Equal(3 * time.Second))
 			gm.Expect(policy.TotalTimeout).To(gm.Equal(10 * time.Second))
 			gm.Expect(policy.MaxRetries).To(gm.Equal(5))
@@ -103,6 +108,7 @@ var _ = gg.Describe("ApplyConfigToTxnRollPolicy", func() {
 			gm.Expect(updatedPolicy.TotalTimeout).To(gm.Equal(15 * time.Millisecond))
 			gm.Expect(updatedPolicy.SocketTimeout).To(gm.Equal(3 * time.Millisecond))
 			gm.Expect(updatedPolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(updatedPolicy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(updatedPolicy.SendKey).To(gm.BeFalse())
 		})

--- a/txn_verify_policy.go
+++ b/txn_verify_policy.go
@@ -35,6 +35,7 @@ func NewTxnVerifyPolicy() *TxnVerifyPolicy {
 	mp.SocketTimeout = 3 * time.Second
 	mp.TotalTimeout = 10 * time.Second
 	mp.SleepBetweenRetries = 1 * time.Second
+	mp.SleepMultiplier = 1.0
 
 	return &TxnVerifyPolicy{
 		BatchPolicy: mp,
@@ -123,6 +124,13 @@ func (tvp *TxnVerifyPolicy) mapDynamic(dynConfig *DynConfig) *TxnVerifyPolicy {
 			tvp.SleepBetweenRetries = configValue
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
+			}
+		}
+		if currentConfig.Dynamic.TxnVerify.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.TxnVerify.SleepMultiplier
+			tvp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
 			}
 		}
 		if currentConfig.Dynamic.TxnVerify.Replica != nil {

--- a/txn_verify_policy_config_test.go
+++ b/txn_verify_policy_config_test.go
@@ -50,6 +50,10 @@ var _ = gg.Describe("ApplyConfigToTxnVerifyPolicy", func() {
 								d := 1
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SocketTimeout: func() *int {
 								d := 3
 								return &d
@@ -76,6 +80,7 @@ var _ = gg.Describe("ApplyConfigToTxnVerifyPolicy", func() {
 			gm.Expect(policy.SocketTimeout).To(gm.Equal(3 * time.Second))
 			gm.Expect(policy.MaxRetries).To(gm.Equal(5))
 			gm.Expect(policy.SleepBetweenRetries).To(gm.Equal(1 * time.Second))
+			gm.Expect(policy.SleepMultiplier).To(gm.Equal(1.0))
 			gm.Expect(policy.SendKey).To(gm.BeFalse())
 
 			// Apply the configuration.
@@ -87,6 +92,7 @@ var _ = gg.Describe("ApplyConfigToTxnVerifyPolicy", func() {
 			gm.Expect(updatedPolicy.ReadModeSC).To(gm.Equal(ReadModeSCLinearize))
 			gm.Expect(updatedPolicy.ReplicaPolicy).To(gm.Equal(MASTER))
 			gm.Expect(updatedPolicy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(updatedPolicy.SocketTimeout).To(gm.Equal(3 * time.Millisecond))
 			gm.Expect(updatedPolicy.TotalTimeout).To(gm.Equal(20 * time.Millisecond))
 			gm.Expect(updatedPolicy.MaxRetries).To(gm.Equal(5))

--- a/write_policy.go
+++ b/write_policy.go
@@ -168,6 +168,13 @@ func (wp *WritePolicy) mapDynamic(dynConfig *DynConfig) *WritePolicy {
 				logger.Logger.Info("SleepBetweenRetries set to %s", configValue.String())
 			}
 		}
+		if currentConfig.Dynamic.Write.SleepMultiplier != nil {
+			configValue := *currentConfig.Dynamic.Write.SleepMultiplier
+			wp.SleepMultiplier = configValue
+			if dynConfig.logUpdate.Load() {
+				logger.Logger.Info("SleepMultiplier set to %f", configValue)
+			}
+		}
 		if currentConfig.Dynamic.Write.SocketTimeout != nil {
 			configValue := time.Duration(*currentConfig.Dynamic.Write.SocketTimeout) * time.Millisecond
 			wp.SocketTimeout = configValue

--- a/write_policy_config_test.go
+++ b/write_policy_config_test.go
@@ -59,6 +59,10 @@ var _ = gg.Describe("WritePolicy Config", func() {
 								d := 2
 								return &d
 							}(),
+							SleepMultiplier: func() *float64 {
+								d := 1.5
+								return &d
+							}(),
 							SendKey: func() *bool {
 								r := true
 								return &r
@@ -84,6 +88,7 @@ var _ = gg.Describe("WritePolicy Config", func() {
 			gm.Expect(policy.MaxRetries).To(gm.Equal(0))
 			gm.Expect(policy.DurableDelete).To(gm.BeFalse())
 			gm.Expect(policy.SleepBetweenRetries).To(gm.Equal(1 * time.Millisecond))
+			gm.Expect(policy.SleepMultiplier).To(gm.Equal(1.0))
 			gm.Expect(policy.SendKey).To(gm.BeFalse())
 
 			updatedPolicy := policy.patchDynamic(config)
@@ -95,6 +100,7 @@ var _ = gg.Describe("WritePolicy Config", func() {
 			gm.Expect(updatedPolicy.MaxRetries).To(gm.Equal(3))
 			gm.Expect(updatedPolicy.DurableDelete).To(gm.BeTrue())
 			gm.Expect(updatedPolicy.SleepBetweenRetries).To(gm.Equal(2 * time.Millisecond))
+			gm.Expect(updatedPolicy.SleepMultiplier).To(gm.Equal(1.5))
 			gm.Expect(updatedPolicy.SendKey).To(gm.BeTrue())
 			gm.Expect(updatedPolicy.ReplicaPolicy).To(gm.Equal(PREFER_RACK))
 		})


### PR DESCRIPTION
Added `sleepMutliplier` param to be part of dynamic config,
Also ensure `sleepMutliplier` to be applied consistently in conjunction with `sleepBetweenRetries`