### PR TITLE
CLIENT-4632 Fixes executeSingle iterates all records instead of node-assigned offsets

### DIFF
--- a/batch_command_delete.go
+++ b/batch_command_delete.go
@@ -186,11 +186,12 @@ func (cmd *batchCommandDelete) commandType() commandType {
 
 func (cmd *batchCommandDelete) executeSingle(client *Client) Error {
 	policy := cmd.batchDeletePolicy.toWritePolicy(cmd.policy, client.dynConfig)
-	for i, key := range cmd.keys {
+	for _, offset := range cmd.batch.offsets {
+		key := cmd.keys[offset]
 		res, err := client.Operate(policy, key, DeleteOp())
-		cmd.records[i].setRecord(res)
+		cmd.records[offset].setRecord(res)
 		if err != nil {
-			cmd.records[i].setRawError(err)
+			cmd.records[offset].setRawError(err)
 
 			// Key not found is NOT an error for batch requests
 			if err.resultCode() == types.KEY_NOT_FOUND_ERROR {
@@ -209,7 +210,7 @@ func (cmd *batchCommandDelete) executeSingle(client *Client) Error {
 }
 
 func (cmd *batchCommandDelete) Execute() Error {
-	if len(cmd.keys) == 1 {
+	if len(cmd.batch.offsets) == 1 {
 		return cmd.executeSingle(cmd.client)
 	}
 	return cmd.execute(cmd)

--- a/batch_command_operate.go
+++ b/batch_command_operate.go
@@ -239,7 +239,8 @@ func (cmd *batchCommandOperate) parseRecord(key *Key, opCount int, generation, e
 func (cmd *batchCommandOperate) executeSingle(client *Client) Error {
 	var res *Record
 	var err Error
-	for _, br := range cmd.records {
+	for _, offset := range cmd.batch.offsets {
+		br := cmd.records[offset]
 
 		switch br := br.(type) {
 		case *BatchRead:
@@ -288,7 +289,7 @@ func (cmd *batchCommandOperate) executeSingle(client *Client) Error {
 }
 
 func (cmd *batchCommandOperate) Execute() Error {
-	if cmd.objects == nil && len(cmd.records) == 1 {
+	if cmd.objects == nil && len(cmd.batch.offsets) == 1 {
 		return cmd.executeSingle(cmd.client)
 	}
 	return cmd.execute(cmd)

--- a/batch_command_udf.go
+++ b/batch_command_udf.go
@@ -194,13 +194,14 @@ func (cmd *batchCommandUDF) isRead() bool {
 }
 
 func (cmd *batchCommandUDF) executeSingle(client *Client) Error {
-	for i, key := range cmd.keys {
+	for _, offset := range cmd.batch.offsets {
+		key := cmd.keys[offset]
 		policy := cmd.batchUDFPolicy.toWritePolicy(cmd.policy, client.dynConfig)
 		policy.RespondPerEachOp = true
 		res, err := client.execute(policy, key, cmd.packageName, cmd.functionName, cmd.args...)
-		cmd.records[i].setRecord(res)
+		cmd.records[offset].setRecord(res)
 		if err != nil {
-			cmd.records[i].setRawError(err)
+			cmd.records[offset].setRawError(err)
 
 			// Key not found is NOT an error for batch requests
 			if err.resultCode() == types.KEY_NOT_FOUND_ERROR {
@@ -219,7 +220,7 @@ func (cmd *batchCommandUDF) executeSingle(client *Client) Error {
 }
 
 func (cmd *batchCommandUDF) Execute() Error {
-	if len(cmd.keys) == 1 {
+	if len(cmd.batch.offsets) == 1 {
 		return cmd.executeSingle(cmd.client)
 	}
 	return cmd.execute(cmd)

--- a/batch_execute_single_test.go
+++ b/batch_execute_single_test.go
@@ -1,0 +1,149 @@
+//go:build !app_engine
+
+// Copyright 2014-2024 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aerospike_test
+
+import (
+	"time"
+
+	as "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/aerospike/aerospike-client-go/v8/types"
+
+	gg "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+)
+
+// Tests for https://github.com/aerospike/aerospike-client-go/pull/655
+//
+// When a batch node has exactly 1 key assigned to it, several batch command
+// types fall back to executeSingle which incorrectly iterates ALL records/keys
+// in the entire batch instead of only the record(s) assigned to the current
+// node via cmd.batch.offsets.
+//
+// These tests call executeSingle directly (via helpers in helper_test.go) with
+// controlled offsets. After the call, only records at the specified offsets
+// should be populated — all others must remain untouched.
+// If executeSingle ignores offsets and iterates all records, non-offset records
+// will also be populated and the test will fail.
+var _ = gg.Describe("Batch executeSingle offset correctness", func() {
+	var ns = *namespace
+	var set = randString(50)
+	var binName = "val"
+	var keyCount = 5
+
+	// offsets simulates a node that was assigned only keys at indices 1 and 3
+	var offsets = []int{1, 3}
+
+	var keys []*as.Key
+	var bpolicy *as.BatchPolicy
+	var wpolicy *as.WritePolicy
+
+	gg.BeforeEach(func() {
+		bpolicy = as.NewBatchPolicy()
+		bpolicy.TotalTimeout = 15 * time.Second
+		bpolicy.SocketTimeout = 5 * time.Second
+
+		wpolicy = as.NewWritePolicy(0, 0)
+
+		// Seed records with distinct values: key i -> bin "val" = i
+		keys = make([]*as.Key, keyCount)
+		for i := 0; i < keyCount; i++ {
+			var err error
+			keys[i], err = as.NewKey(ns, set, i)
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+			err = client.PutBins(wpolicy, keys[i], as.NewBin(binName, i))
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+		}
+	})
+
+	gg.It("executeSingle must only process offset records (batchIndexCommandGet)", func() {
+		reads := make([]*as.BatchRead, keyCount)
+		for j := 0; j < keyCount; j++ {
+			reads[j] = as.NewBatchRead(nil, keys[j], []string{binName})
+		}
+
+		err := as.ExecuteSingleBatchIndexGet(client, bpolicy, reads, offsets)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		for j, br := range reads {
+			if j == 1 || j == 3 {
+				gm.Expect(br.Record).ToNot(gm.BeNil(), "record at offset index %d should be populated", j)
+				gm.Expect(br.Record.Bins[binName]).To(gm.Equal(j),
+					"record at offset index %d has wrong value: expected %d, got %v", j, j, br.Record.Bins[binName])
+			} else {
+				gm.Expect(br.Record).To(gm.BeNil(),
+					"record at non-offset index %d should be nil but was populated", j)
+			}
+		}
+	})
+
+	gg.It("executeSingle must only process offset records (batchCommandOperate)", func() {
+		records := make([]as.BatchRecordIfc, keyCount)
+		for j := 0; j < keyCount; j++ {
+			records[j] = as.NewBatchRead(as.NewBatchReadPolicy(), keys[j], []string{binName})
+		}
+
+		err := as.ExecuteSingleBatchOperate(client, bpolicy, records, offsets)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		for j, rec := range records {
+			br := rec.BatchRec()
+			if j == 1 || j == 3 {
+				gm.Expect(br.Record).ToNot(gm.BeNil(), "record at offset index %d should be populated", j)
+				gm.Expect(br.Record.Bins[binName]).To(gm.Equal(j),
+					"record at offset index %d has wrong value: expected %d, got %v", j, j, br.Record.Bins[binName])
+			} else {
+				gm.Expect(br.Record).To(gm.BeNil(),
+					"record at non-offset index %d should be nil but was populated", j)
+			}
+		}
+	})
+
+	gg.It("executeSingle must only process offset records (batchCommandDelete)", func() {
+		records := make([]*as.BatchRecord, keyCount)
+		for j := 0; j < keyCount; j++ {
+			records[j] = &as.BatchRecord{
+				Key: keys[j],
+			}
+		}
+
+		err := as.ExecuteSingleBatchDelete(client, bpolicy, as.NewBatchDeletePolicy(), keys, records, offsets)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		for j, br := range records {
+			if j == 1 || j == 3 {
+				gm.Expect(br.ResultCode).To(gm.Equal(types.OK),
+					"record at offset index %d has result code %s, expected OK", j, br.ResultCode)
+			} else {
+				gm.Expect(br.Record).To(gm.BeNil(),
+					"record at non-offset index %d should be nil but was populated", j)
+			}
+		}
+
+		// Verify only the offset keys were deleted
+		exists, err := client.BatchExists(bpolicy, keys)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		for j, e := range exists {
+			if j == 1 || j == 3 {
+				gm.Expect(e).To(gm.BeFalse(),
+					"key at offset index %d should have been deleted but still exists", j)
+			} else {
+				gm.Expect(e).To(gm.BeTrue(),
+					"key at non-offset index %d should still exist but was deleted", j)
+			}
+		}
+	})
+})

--- a/batch_execute_single_test.go
+++ b/batch_execute_single_test.go
@@ -112,6 +112,37 @@ var _ = gg.Describe("Batch executeSingle offset correctness", func() {
 		}
 	})
 
+	gg.It("executeSingle must only process offset records (batchCommandUDF)", func() {
+		luaCode := `function rec_create(rec, bins)
+		    return bins
+		end`
+
+		removeUDF("test_single_ops.lua")
+		registerUDF(luaCode, "test_single_ops.lua")
+
+		records := make([]*as.BatchRecord, keyCount)
+		for j := 0; j < keyCount; j++ {
+			records[j] = &as.BatchRecord{
+				Key: keys[j],
+			}
+		}
+
+		args := []as.Value{as.NewMapValue(map[any]any{"bin1_str": "a"})}
+		err := as.ExecuteSingleBatchUDF(client, bpolicy, as.NewBatchUDFPolicy(), keys, "test_single_ops", "rec_create", args, records, offsets)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		for j, br := range records {
+			if j == 1 || j == 3 {
+				gm.Expect(br.ResultCode).To(gm.Equal(types.OK),
+					"record at offset index %d has result code %s, expected OK", j, br.ResultCode)
+				gm.Expect(br.Record).ToNot(gm.BeNil(), "record at offset index %d should be populated", j)
+			} else {
+				gm.Expect(br.Record).To(gm.BeNil(),
+					"record at non-offset index %d should be nil but was populated", j)
+			}
+		}
+	})
+
 	gg.It("executeSingle must only process offset records (batchCommandDelete)", func() {
 		records := make([]*as.BatchRecord, keyCount)
 		for j := 0; j < keyCount; j++ {

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -68,7 +68,8 @@ func (cmd *batchIndexCommandGet) Execute() Error {
 }
 
 func (cmd *batchIndexCommandGet) executeSingle(client *Client) Error {
-	for _, br := range cmd.records {
+	for _, offset := range cmd.batch.offsets {
+		br := cmd.records[offset]
 		var ops []*Operation
 		if br.headerOnly() {
 			ops = []*Operation{GetHeaderOp()}

--- a/helper_test.go
+++ b/helper_test.go
@@ -166,3 +166,11 @@ func ExecuteSingleBatchDelete(client *Client, policy *BatchPolicy, deletePolicy 
 	cmd := newBatchCommandDelete(client, batch, policy, deletePolicy, keys, records, nil)
 	return cmd.executeSingle(client)
 }
+
+// ExecuteSingleBatchUDF calls batchCommandUDF.executeSingle with
+// the given keys, records, and offsets, bypassing the normal Execute condition.
+func ExecuteSingleBatchUDF(client *Client, policy *BatchPolicy, udfPolicy *BatchUDFPolicy, keys []*Key, packageName, functionName string, args []Value, records []*BatchRecord, offsets []int) Error {
+	batch := &batchNode{offsets: offsets}
+	cmd := newBatchCommandUDF(client, batch, policy, udfPolicy, keys, packageName, functionName, args, records, nil)
+	return cmd.executeSingle(client)
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -142,3 +142,27 @@ func (host *Host) Equals(other *Host) bool {
 func NewExpression(e any) *Expression {
 	return newExpression(e)
 }
+
+// ExecuteSingleBatchOperate calls batchCommandOperate.executeSingle with
+// the given records and offsets, bypassing the normal Execute condition.
+func ExecuteSingleBatchOperate(client *Client, policy *BatchPolicy, records []BatchRecordIfc, offsets []int) Error {
+	batch := &batchNode{offsets: offsets}
+	cmd := newBatchCommandOperate(client, batch, policy, records)
+	return cmd.executeSingle(client)
+}
+
+// ExecuteSingleBatchIndexGet calls batchIndexCommandGet.executeSingle with
+// the given records and offsets, bypassing the normal Execute condition.
+func ExecuteSingleBatchIndexGet(client *Client, policy *BatchPolicy, records []*BatchRead, offsets []int) Error {
+	batch := &batchNode{offsets: offsets}
+	cmd := newBatchIndexCommandGet(client, batch, policy, records, false)
+	return cmd.executeSingle(client)
+}
+
+// ExecuteSingleBatchDelete calls batchCommandDelete.executeSingle with
+// the given keys, records, and offsets, bypassing the normal Execute condition.
+func ExecuteSingleBatchDelete(client *Client, policy *BatchPolicy, deletePolicy *BatchDeletePolicy, keys []*Key, records []*BatchRecord, offsets []int) Error {
+	batch := &batchNode{offsets: offsets}
+	cmd := newBatchCommandDelete(client, batch, policy, deletePolicy, keys, records, nil)
+	return cmd.executeSingle(client)
+}

--- a/txn_roll_batch.go
+++ b/txn_roll_batch.go
@@ -187,8 +187,8 @@ func (cmd *batchTxnRollCommand) inDoubt() {
 		return
 	}
 
-	for index := range cmd.batch.offsets {
-		record := cmd.records[index]
+	for _, offset := range cmd.batch.offsets {
+		record := cmd.records[offset]
 
 		if record.ResultCode == types.NO_RESPONSE {
 			record.InDoubt = true


### PR DESCRIPTION
When a batch node has exactly 1 key assigned to it, several batch command types fall back to `executeSingle` which
   incorrectly iterates **all records/keys** in the entire batch instead of only the record(s) assigned to the current node
    via `cmd.batch.offsets`.

   This causes N sequential `client.Operate` round trips instead of 1, where N is the total number of keys in the batch.

   ### Impact

   On cross-datacenter connections with ~2.5ms RTT, a `BatchGetComplex` with 10 keys takes **~25ms instead of ~3ms**
   because `executeSingle` sends 10 individual Operate calls sequentially.

   ### Root cause

   Compare the **correct** implementation in `batchCommandGet.executeSingle`:

   ```go
   // Correct: iterates only this node's assigned keys
   for _, offset := range cmd.batch.offsets {
       cmd.records[offset], err = client.Get(...)
   }
   ```

   With the **buggy** implementation in `batchIndexCommandGet.executeSingle`:

   ```go
   // Bug: iterates ALL records in the batch
   for _, br := range cmd.records {
       client.Operate(...)
   }
   ```

   ### Affected files

   | File | Execute condition | Loop iterates | Bug |
   |------|------------------|---------------|-----|
   | `batch_command_get.go` | `len(cmd.batch.offsets) == 1` | `cmd.batch.offsets` | ✅ Correct |
   | `batch_command_exists.go` | `len(cmd.batch.offsets) == 1` | `cmd.batch.offsets` | ✅ Correct |
   | `batch_index_command_get.go` | `len(cmd.batch.offsets) == 1` | `cmd.records` | ❌ Bug |
   | `batch_command_operate.go` | `len(cmd.records) == 1` | `cmd.records` | ❌ Bug |
   | `batch_command_delete.go` | `len(cmd.keys) == 1` | `cmd.keys` | ❌ Bug |
   | `batch_command_udf.go` | `len(cmd.keys) == 1` | `cmd.keys` | ❌ Bug |

   ### Fix

   For all affected files:
   1. Check `len(cmd.batch.offsets) == 1` instead of `len(cmd.records/keys) == 1`
   2. Iterate `cmd.batch.offsets` and index into `cmd.records/keys` by offset

   ### Reproduction

   Test against a 3-node cluster with metrics enabled:

   ```go
   client.EnableMetrics(aero.DefaultMetricsPolicy())
   _, _ = client.Stats() // reset

   for range 100 {
       reads := make([]*aero.BatchRead, 10)
       for i := range 10 {
           reads[i] = aero.NewBatchRead(nil, keys[i], []string{"val"})
       }
       client.BatchGetComplex(bp, reads)
   }

   stats, _ := client.Stats()
   // Check operate-metrics count in cluster-aggregated-stats
   // Expected: 0 (all should use batch protocol)
   // Actual: 1000 (10 Operate calls per iteration)