### PR TITLE
Added a fix that is causing dependabot PRs to fail because of feature conf file not being avaialble for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
               "8.1.2.0": { "version": "8.1.2.0" }
             }
           go_version: ${{ steps.get-go-version.outputs.go-version }}
-          modes: AP,SC
+          modes: ${{ github.actor == 'dependabot[bot]' && 'AP' || 'AP,SC' }}
 
       - name: debug - print input variables
         run: |


### PR DESCRIPTION
Fixing issues where ci if failing because of 

```
Warning: Unexpected input(s) 'aerospike-version', valid inputs are ['server-tag', 'num-nodes', 'container-name-prefix', 
Error: features-file or features-content is required for strong consistency
Error: Process completed with exit code 1.
````