### PR TITLE
CLIENT-4940: change sendkey policy resolution to union of all send-key settings

### DIFF
--- a/batch_command_delete.go
+++ b/batch_command_delete.go
@@ -186,6 +186,10 @@ func (cmd *batchCommandDelete) commandType() commandType {
 
 func (cmd *batchCommandDelete) executeSingle(client *Client) Error {
 	policy := cmd.batchDeletePolicy.toWritePolicy(cmd.policy, client.dynConfig)
+	// Honor sendKey from BOTH the parent BatchPolicy and the per-record policy.
+	// toWritePolicy carries only the per-record value, so OR in the parent's sendKey here.
+	policy.SendKey = cmd.policy.SendKey || (cmd.batchDeletePolicy != nil && cmd.batchDeletePolicy.SendKey)
+
 	for _, offset := range cmd.batch.offsets {
 		key := cmd.keys[offset]
 		res, err := client.Operate(policy, key, DeleteOp())

--- a/batch_command_operate.go
+++ b/batch_command_operate.go
@@ -257,13 +257,18 @@ func (cmd *batchCommandOperate) executeSingle(client *Client) Error {
 			res, err = client.Operate(cmd.client.getUsableBatchReadPolicy(br.Policy).toWritePolicy(cmd.policy, client.dynConfig), br.Key, ops...)
 		case *BatchWrite:
 			policy := cmd.client.getUsableBatchWritePolicy(br.Policy).toWritePolicy(cmd.policy, client.dynConfig)
+			// Honor sendKey from BOTH the parent BatchPolicy and the per-record policy.
+			// toWritePolicy carries only the per-record value, so OR in the parent's sendKey here.
+			policy.SendKey = br.resolveSendKey(&cmd.policy.BasePolicy, cmd.client)
 			policy.RespondPerEachOp = true
 			res, err = client.Operate(policy, br.Key, br.Ops...)
 		case *BatchDelete:
 			policy := cmd.client.getUsableBatchDeletePolicy(br.Policy).toWritePolicy(cmd.policy, client.dynConfig)
+			policy.SendKey = br.resolveSendKey(&cmd.policy.BasePolicy, cmd.client)
 			res, err = client.Operate(policy, br.Key, DeleteOp())
 		case *BatchUDF:
 			policy := cmd.client.getUsableBatchUDFPolicy(br.Policy).toWritePolicy(cmd.policy, client.dynConfig)
+			policy.SendKey = br.resolveSendKey(&cmd.policy.BasePolicy, cmd.client)
 			policy.RespondPerEachOp = true
 			res, err = client.execute(policy, br.Key, br.PackageName, br.FunctionName, br.FunctionArgs...)
 		}

--- a/batch_command_udf.go
+++ b/batch_command_udf.go
@@ -197,6 +197,9 @@ func (cmd *batchCommandUDF) executeSingle(client *Client) Error {
 	for _, offset := range cmd.batch.offsets {
 		key := cmd.keys[offset]
 		policy := cmd.batchUDFPolicy.toWritePolicy(cmd.policy, client.dynConfig)
+		// Honor sendKey from BOTH the parent BatchPolicy and the per-record policy.
+		// toWritePolicy carries only the per-record value, so OR in the parent's sendKey here.
+		policy.SendKey = cmd.policy.SendKey || (cmd.batchUDFPolicy != nil && cmd.batchUDFPolicy.SendKey)
 		policy.RespondPerEachOp = true
 		res, err := client.execute(policy, key, cmd.packageName, cmd.functionName, cmd.args...)
 		cmd.records[offset].setRecord(res)

--- a/batch_delete.go
+++ b/batch_delete.go
@@ -65,32 +65,30 @@ func (bd *BatchDelete) equals(obj BatchRecordIfc) bool {
 	return bd.Policy == other.Policy
 }
 
-// Return wire protocol size. For internal use only.
-func (bd *BatchDelete) size(parentPolicy *BasePolicy) (int, Error) {
+// resolveSendKey returns parent ∪ per-record/default/dynamic sendKey. For internal use only.
+func (bd *BatchDelete) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
+	dp := client.getUsableBatchDeletePolicy(bd.Policy)
+	return parentPolicy.SendKey || (dp != nil && dp.SendKey)
+}
+
+// Return wire protocol size. sendKey is pre-resolved so size and write agree. For internal use only.
+func (bd *BatchDelete) size(sendKey bool) (int, Error) {
 	size := 2 // gen(2) = 2
 
-	if bd.Policy != nil {
-		if bd.Policy.FilterExpression != nil {
-			if sz, err := bd.Policy.FilterExpression.size(); err != nil {
-				return -1, err
-			} else {
-				size += sz + int(_FIELD_HEADER_SIZE)
-			}
-		}
-
-		if (bd.Policy.SendKey || parentPolicy.SendKey) && bd.Key.hasValueToSend() {
-			if sz, err := bd.Key.userKey.EstimateSize(); err != nil {
-				return -1, err
-			} else {
-				size += sz + int(_FIELD_HEADER_SIZE) + 1
-			}
-		}
-	} else if parentPolicy.SendKey && bd.Key.hasValueToSend() {
-		sz, err := bd.Key.userKey.EstimateSize()
-		if err != nil {
+	if bd.Policy != nil && bd.Policy.FilterExpression != nil {
+		if sz, err := bd.Policy.FilterExpression.size(); err != nil {
 			return -1, err
+		} else {
+			size += sz + int(_FIELD_HEADER_SIZE)
 		}
-		size += sz + int(_FIELD_HEADER_SIZE) + 1
+	}
+
+	if sendKey && bd.Key.hasValueToSend() {
+		if sz, err := bd.Key.userKey.EstimateSize(); err != nil {
+			return -1, err
+		} else {
+			size += sz + int(_FIELD_HEADER_SIZE) + 1
+		}
 	}
 
 	return size, nil

--- a/batch_delete.go
+++ b/batch_delete.go
@@ -67,8 +67,10 @@ func (bd *BatchDelete) equals(obj BatchRecordIfc) bool {
 
 // resolveSendKey returns parent ∪ per-record/default/dynamic sendKey. For internal use only.
 func (bd *BatchDelete) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
+	// sendKey is the union of parent, cluster default and per-record (dp carries dynamic config).
+	def := client.DefaultBatchDeletePolicy
 	dp := client.getUsableBatchDeletePolicy(bd.Policy)
-	return parentPolicy.SendKey || (dp != nil && dp.SendKey)
+	return parentPolicy.SendKey || (def != nil && def.SendKey) || (dp != nil && dp.SendKey)
 }
 
 // Return wire protocol size. sendKey is pre-resolved so size and write agree. For internal use only.

--- a/batch_delete_policy.go
+++ b/batch_delete_policy.go
@@ -140,7 +140,10 @@ func (bdp *BatchDeletePolicy) mapDynamic(dynConfig *DynConfig) *BatchDeletePolic
 		}
 		if config.Dynamic.BatchDelete.SendKey != nil {
 			configValue := *config.Dynamic.BatchDelete.SendKey
-			bdp.SendKey = configValue
+			// Dynamic config sendKey only overrides when true
+			if configValue {
+				bdp.SendKey = true
+			}
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SendKey set to %t", configValue)
 			}

--- a/batch_read.go
+++ b/batch_read.go
@@ -118,7 +118,8 @@ func (br *BatchRead) equals(obj BatchRecordIfc) bool {
 }
 
 // Return wire protocol size. For internal use only.
-func (br *BatchRead) size(parentPolicy *BasePolicy) (int, Error) {
+// size: sendKey is ignored — batch reads never store the user key. For internal use only.
+func (br *BatchRead) size(sendKey bool) (int, Error) {
 	size := 0
 
 	if br.Policy != nil {

--- a/batch_read_repeat_optimisation_test.go
+++ b/batch_read_repeat_optimisation_test.go
@@ -19,9 +19,9 @@ import (
 	gm "github.com/onsi/gomega"
 )
 
-// A read record must stay eligible for the batch repeat flag regardless of the batch policy(parent policy) sendKey
-// (reads never send the key). We encode and compare sizes: a repeated read costs ~1 byte vs a full
-// namespace/set header, so the repeated-read batch must be smaller; if equal, the repeat was lost.
+// A read record must stay eligible for the batch repeat flag regardless of the parent BatchPolicy
+// sendKey (reads never send the key). We encode and compare sizes: a repeated read costs ~1 byte
+// vs a full namespace/set header, so the repeated-read batch must be smaller; if equal, repeat was lost.
 
 var _ = gg.Describe("Batch read repeat optimization is preserved regardless of parent BatchPolicy.SendKey", func() {
 

--- a/batch_read_repeat_optimisation_test.go
+++ b/batch_read_repeat_optimisation_test.go
@@ -1,0 +1,84 @@
+// Copyright 2014-2026 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aerospike
+
+import (
+	gg "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+)
+
+// A read record must stay eligible for the batch repeat flag regardless of the batch policy(parent policy) sendKey
+// (reads never send the key). We encode and compare sizes: a repeated read costs ~1 byte vs a full
+// namespace/set header, so the repeated-read batch must be smaller; if equal, the repeat was lost.
+
+var _ = gg.Describe("Batch read repeat optimization is preserved regardless of parent BatchPolicy.SendKey", func() {
+
+	// Minimal client whose nil-policy lookups resolve to the built-in defaults (no server).
+	newEncodeClient := func() *Client {
+		return &Client{
+			DefaultBatchPolicy:       NewBatchPolicy(),
+			DefaultBatchReadPolicy:   NewBatchReadPolicy(),
+			DefaultBatchWritePolicy:  NewBatchWritePolicy(),
+			DefaultBatchDeletePolicy: NewBatchDeletePolicy(),
+			DefaultBatchUDFPolicy:    NewBatchUDFPolicy(),
+		}
+	}
+
+	offsets := func(n int) BatchOffsets {
+		o := make([]int, n)
+		for i := range o {
+			o[i] = i
+		}
+		return &batchOffsetsNative{offsets: o}
+	}
+
+	rKey, _ := NewKey("test", "ck4898_repeat", "r")
+	wKey, _ := NewKey("test", "ck4898_repeat", "w")
+
+	// Encodes a 3-record mixed batch [write, read, third] and returns the wire size. `third` is
+	// produced from the shared read so the caller can pass back the SAME pointer (repeat-eligible)
+	// or a distinct one (full header).
+	encodeSize := func(parentSendKey bool, third func(shared BatchRecordIfc) BatchRecordIfc) int {
+		client := newEncodeClient()
+		policy := NewBatchPolicy()
+		policy.SendKey = parentSendKey
+
+		bw := NewBatchWrite(nil, wKey, PutOp(NewBin("b", 1)))
+		shared := NewBatchRead(nil, rKey, []string{"b"})
+
+		records := []BatchRecordIfc{bw, shared, third(shared)}
+		cmd := &baseCommand{}
+		_, err := cmd.setBatchOperateIfcOffsets(client, policy, records, offsets(3))
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		return cmd.dataOffset
+	}
+
+	repeated := func(shared BatchRecordIfc) BatchRecordIfc { return shared } // same pointer → repeat
+	distinct := func(BatchRecordIfc) BatchRecordIfc {                        // new pointer → full header
+		return NewBatchRead(nil, rKey, []string{"b"})
+	}
+
+	// Read repeat must apply regardless of the parent's sendKey — reads never send the key, so a
+	// repeated read encodes ~1 byte while a distinct read needs a full namespace/set header. This
+	// must hold for parent SendKey both true (the bug: parent must not block read repeat) and false.
+	gg.It("read records keep the repeat flag independent of parent sendKey (true & false)", func() {
+		for _, parentSendKey := range []bool{true, false} {
+			rep := encodeSize(parentSendKey, repeated)
+			dist := encodeSize(parentSendKey, distinct)
+			gm.Expect(rep).To(gm.BeNumerically("<", dist),
+				"read repeat must apply with parent BatchPolicy.SendKey=%v", parentSendKey)
+		}
+	})
+})

--- a/batch_record.go
+++ b/batch_record.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2022 Aerospike, Inc.
+// Copyright 2014-2026 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,8 @@ type BatchRecordIfc interface {
 	chainError(err Error)
 	String() string
 	getType() batchRecordType
-	size(parentPolicy *BasePolicy) (int, Error)
+	size(sendKey bool) (int, Error)
+	resolveSendKey(parentPolicy *BasePolicy, client *Client) bool
 	equals(BatchRecordIfc) bool
 }
 
@@ -167,6 +168,11 @@ func (br *BatchRecord) getType() batchRecordType {
 }
 
 // Return wire protocol size. For internal use only.
-func (br *BatchRecord) size(parentPolicy *BasePolicy) (int, Error) {
+func (br *BatchRecord) size(sendKey bool) (int, Error) {
 	panic(unreachable)
+}
+
+// resolveSendKey: reads (and any type not overriding this) never send the key. For internal use only.
+func (br *BatchRecord) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
+	return false
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -1075,6 +1075,25 @@ var _ = gg.Describe("CLIENT-4898 BatchWrite sendKey", func() {
 			expectSendKeyStored(ns, set, keys, false)
 		}
 	})
+
+	// Cluster default must be honored even when a per-record policy with SendKey=false is present.
+	gg.It("cluster DefaultBatchWritePolicy.SendKey=true is honored despite a per-record SendKey=false", func() {
+		orig := client.DefaultBatchWritePolicy
+		defer func() { client.DefaultBatchWritePolicy = orig }()
+		def := as.NewBatchWritePolicy()
+		def.SendKey = true // cluster default enables sendKey
+		client.DefaultBatchWritePolicy = def
+
+		for _, sz := range sendKeyBatchSizes {
+			bp := as.NewBatchPolicy()
+			bp.SendKey = false // parent does NOT request the key
+			wp := as.NewBatchWritePolicy()
+			wp.SendKey = false // per-record policy present but does NOT request the key
+			keys := sendKeyKeys(ns, set, "w-clusterdef-"+sz.name, sz.n)
+			runSendKeyBatchWrites(client, keys, bp, wp)
+			expectSendKeyStored(ns, set, keys, true)
+		}
+	})
 })
 
 // ── BatchUDF (dedicated client.BatchExecute path) ────────────────────────────

--- a/batch_test.go
+++ b/batch_test.go
@@ -19,7 +19,9 @@ package aerospike_test
 import (
 	"math"
 	"math/rand"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -1029,3 +1031,231 @@ var _ = gg.Describe("Aerospike", func() {
 		})
 	})
 })
+
+// ── BatchWrite ───────────────────────────────────────────────────────────────
+
+var _ = gg.Describe("CLIENT-4898 BatchWrite sendKey", func() {
+	ns := *namespace
+	set := "ck4898_write"
+
+	gg.It("resolves sendKey as the union of parent and per-record policy (single & multi record)", func() {
+		for _, sz := range sendKeyBatchSizes {
+			// parent BatchPolicy.SendKey=true, per-record nil → key stored
+			bp := as.NewBatchPolicy()
+			bp.SendKey = true
+			keys := sendKeyKeys(ns, set, "w-parent-"+sz.name, sz.n)
+			runSendKeyBatchWrites(client, keys, bp, nil)
+			expectSendKeyStored(ns, set, keys, true)
+
+			// per-record BatchWritePolicy.SendKey=true, parent false → key stored
+			bp = as.NewBatchPolicy()
+			bp.SendKey = false
+			wp := as.NewBatchWritePolicy()
+			wp.SendKey = true
+			keys = sendKeyKeys(ns, set, "w-perrec-"+sz.name, sz.n)
+			runSendKeyBatchWrites(client, keys, bp, wp)
+			expectSendKeyStored(ns, set, keys, true)
+
+			// parent SendKey=true overrides per-record SendKey=false (union) → key stored
+			bp = as.NewBatchPolicy()
+			bp.SendKey = true
+			wp = as.NewBatchWritePolicy()
+			wp.SendKey = false
+			keys = sendKeyKeys(ns, set, "w-union-"+sz.name, sz.n)
+			runSendKeyBatchWrites(client, keys, bp, wp)
+			expectSendKeyStored(ns, set, keys, true)
+
+			// neither parent nor per-record set → key NOT stored
+			bp = as.NewBatchPolicy()
+			bp.SendKey = false
+			wp = as.NewBatchWritePolicy()
+			wp.SendKey = false
+			keys = sendKeyKeys(ns, set, "w-none-"+sz.name, sz.n)
+			runSendKeyBatchWrites(client, keys, bp, wp)
+			expectSendKeyStored(ns, set, keys, false)
+		}
+	})
+})
+
+// ── BatchUDF (dedicated client.BatchExecute path) ────────────────────────────
+
+var _ = gg.Describe("CLIENT-4898 BatchUDF sendKey", func() {
+	ns := *namespace
+	set := "ck4898_udf"
+
+	gg.It("resolves sendKey from parent or per-record policy (single & multi record)", func() {
+		for _, sz := range sendKeyBatchSizes {
+			// parent BatchPolicy.SendKey=true, per-record nil → key stored
+			bp := as.NewBatchPolicy()
+			bp.SendKey = true
+			keys := sendKeyKeys(ns, set, "u-parent-"+sz.name, sz.n)
+			runSendKeyBatchUDF(client, keys, bp, nil)
+			expectSendKeyStored(ns, set, keys, true)
+
+			// per-record BatchUDFPolicy.SendKey=true, parent false → key stored
+			bp = as.NewBatchPolicy()
+			bp.SendKey = false
+			up := as.NewBatchUDFPolicy()
+			up.SendKey = true
+			keys = sendKeyKeys(ns, set, "u-perrec-"+sz.name, sz.n)
+			runSendKeyBatchUDF(client, keys, bp, up)
+			expectSendKeyStored(ns, set, keys, true)
+		}
+	})
+})
+
+// ── BatchDelete (dedicated client.BatchDelete path) ──────────────────────────
+//
+// sendKey on a delete stores the key on the (durable) tombstone, which is not observable via a
+// normal scan. This is a functional/smoke test: the parent-union code path must encode and run
+// cleanly for both single- and multi-record deletes.
+
+var _ = gg.Describe("CLIENT-4898 BatchDelete sendKey [smoke — tombstone key not scannable]", func() {
+	ns := *namespace
+	set := "ck4898_delete"
+
+	gg.It("parent BatchPolicy.SendKey=true deletes cleanly (single & multi record)", func() {
+		for _, sz := range sendKeyBatchSizes {
+			bp := as.NewBatchPolicy()
+			bp.SendKey = true
+			keys := sendKeyKeys(ns, set, "d-parent-"+sz.name, sz.n)
+			for i, k := range keys {
+				gm.Expect(client.PutBins(nil, k, as.NewBin("v", i))).ToNot(gm.HaveOccurred())
+			}
+
+			recs, err := client.BatchDelete(bp, nil, keys)
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+			for _, r := range recs {
+				gm.Expect(r.ResultCode).To(gm.Equal(types.OK))
+			}
+			for _, k := range keys {
+				ex, err := client.Exists(nil, k)
+				gm.Expect(err).ToNot(gm.HaveOccurred())
+				gm.Expect(ex).To(gm.BeFalse(), "record should be deleted")
+			}
+		}
+	})
+})
+
+// ── Mixed batch (heterogeneous BatchOperate) ─────────────────────────────────
+
+var _ = gg.Describe("CLIENT-4898 mixed batch sendKey", func() {
+	ns := *namespace
+	set := "ck4898_mixed"
+
+	gg.It("parent SendKey=true: write/UDF records store the key, read records do not", func() {
+		ensureSendKeyUDF()
+
+		bp := as.NewBatchPolicy()
+		bp.SendKey = true
+
+		wKey := sendKeyKeys(ns, set, "mx-write", 1)[0]
+		uKey := sendKeyKeys(ns, set, "mx-udf", 1)[0]
+		rKey := sendKeyKeys(ns, set, "mx-read", 1)[0]
+		// Seed the read target (with a nil policy, so its own key is NOT stored).
+		gm.Expect(client.PutBins(nil, rKey, as.NewBin("v", 1))).ToNot(gm.HaveOccurred())
+
+		recs := []as.BatchRecordIfc{
+			as.NewBatchWrite(nil, wKey, as.PutOp(as.NewBin("v", 1))),
+			as.NewBatchUDF(nil, uKey, "client4898udf", "writeBin", as.NewValue("v"), as.NewValue(1)),
+			as.NewBatchRead(nil, rKey, []string{"v"}),
+		}
+		gm.Expect(client.BatchOperate(bp, recs)).ToNot(gm.HaveOccurred())
+
+		// Writes honor parent sendKey; the read never stores a key.
+		gm.Expect(sendKeyStored(ns, set, wKey)).To(gm.BeTrue(), "write record must store key under parent SendKey=true")
+		gm.Expect(sendKeyStored(ns, set, uKey)).To(gm.BeTrue(), "UDF record must store key under parent SendKey=true")
+		gm.Expect(sendKeyStored(ns, set, rKey)).To(gm.BeFalse(), "read record must never store a key")
+	})
+})
+
+// Shared helpers for the batch sendKey tests (batch_test.go, dynconfig_serialze_test.go).
+var sendKeyBatchSizes = []struct {
+	name string
+	n    int
+}{
+	{"single-record", 1},
+	{"multi-record", 3},
+}
+
+// sendKeyStored reports whether the SERVER stored the user key for this digest. A scan is the
+// only correct probe: the client does not supply the key, so Record.Key.Value() is non-nil ONLY
+// if the server stored and echoed it at write time. (client.Get can't tell — it already holds
+// the key it queried with.)
+func sendKeyStored(ns, set string, key *as.Key) bool {
+	rs, err := client.ScanAll(as.NewScanPolicy(), ns, set)
+	if err != nil {
+		return false
+	}
+	defer rs.Close()
+
+	want := string(key.Digest())
+	for res := range rs.Results() {
+		if res.Err != nil || res.Record == nil || res.Record.Key == nil {
+			continue
+		}
+		if string(res.Record.Key.Digest()) == want {
+			return res.Record.Key.Value() != nil
+		}
+	}
+	return false
+}
+
+func expectSendKeyStored(ns, set string, keys []*as.Key, want bool) {
+	for _, k := range keys {
+		gm.ExpectWithOffset(1, sendKeyStored(ns, set, k)).To(gm.Equal(want),
+			"key %v: server-stored mismatch (want stored=%v)", k.Value(), want)
+	}
+}
+
+// sendKeyKeys builds n distinct keys under a unique prefix (prefixes keep scenarios from
+// colliding in the shared set's scan).
+func sendKeyKeys(ns, set, prefix string, n int) []*as.Key {
+	keys := make([]*as.Key, n)
+	for i := 0; i < n; i++ {
+		k, err := as.NewKey(ns, set, prefix+"-"+strconv.Itoa(i))
+		gm.ExpectWithOffset(1, err).ToNot(gm.HaveOccurred())
+		keys[i] = k
+	}
+	return keys
+}
+
+// runWrites issues a BatchWrite per key and returns the keys.
+func runSendKeyBatchWrites(c *as.Client, keys []*as.Key, bp *as.BatchPolicy, wp *as.BatchWritePolicy) {
+	recs := make([]as.BatchRecordIfc, len(keys))
+	for i, k := range keys {
+		recs[i] = as.NewBatchWrite(wp, k, as.PutOp(as.NewBin("v", i)))
+	}
+	gm.ExpectWithOffset(1, c.BatchOperate(bp, recs)).ToNot(gm.HaveOccurred())
+}
+
+// The UDF writes a bin, so the record is created and its key becomes observable via scan.
+const sendKeyUDFBody = `
+function writeBin(rec, name, val)
+    rec[name] = val
+    if aerospike:exists(rec) then
+        aerospike:update(rec)
+    else
+        aerospike:create(rec)
+    end
+end
+`
+
+var sendKeyUDFOnce sync.Once
+
+func ensureSendKeyUDF() {
+	sendKeyUDFOnce.Do(func() {
+		t, err := client.RegisterUDF(as.NewWritePolicy(0, 0), []byte(sendKeyUDFBody), "client4898udf.lua", as.LUA)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		gm.Expect(<-t.OnComplete()).ToNot(gm.HaveOccurred())
+	})
+}
+
+func runSendKeyBatchUDF(c *as.Client, keys []*as.Key, bp *as.BatchPolicy, up *as.BatchUDFPolicy) {
+	ensureSendKeyUDF()
+	recs, err := c.BatchExecute(bp, up, keys, "client4898udf", "writeBin", as.NewValue("v"), as.NewValue(1))
+	gm.ExpectWithOffset(1, err).ToNot(gm.HaveOccurred())
+	for _, r := range recs {
+		gm.ExpectWithOffset(1, r.ResultCode).To(gm.Equal(types.OK))
+	}
+}

--- a/batch_udf.go
+++ b/batch_udf.go
@@ -83,32 +83,30 @@ func (bu *BatchUDF) equals(obj BatchRecordIfc) bool {
 	}
 }
 
-// Return wire protocol size. For internal use only.
-func (bu *BatchUDF) size(parentPolicy *BasePolicy) (int, Error) {
+// resolveSendKey returns parent ∪ per-record/default/dynamic sendKey. For internal use only.
+func (bu *BatchUDF) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
+	udfPolicy := client.getUsableBatchUDFPolicy(bu.Policy)
+	return parentPolicy.SendKey || (udfPolicy != nil && udfPolicy.SendKey)
+}
+
+// Return wire protocol size. sendKey is pre-resolved so size and write agree. For internal use only.
+func (bu *BatchUDF) size(sendKey bool) (int, Error) {
 	size := 2 // gen(2) = 2
 
-	if bu.Policy != nil {
-		if bu.Policy.FilterExpression != nil {
-			sz, err := bu.Policy.FilterExpression.size()
-			if err != nil {
-				return -1, err
-			}
-			size += sz + int(_FIELD_HEADER_SIZE)
-		}
-
-		if (bu.Policy.SendKey || parentPolicy.SendKey) && bu.Key.hasValueToSend() {
-			if sz, err := bu.Key.userKey.EstimateSize(); err != nil {
-				return -1, err
-			} else {
-				size += sz + int(_FIELD_HEADER_SIZE) + 1
-			}
-		}
-	} else if parentPolicy.SendKey && bu.Key.hasValueToSend() {
-		sz, err := bu.Key.userKey.EstimateSize()
+	if bu.Policy != nil && bu.Policy.FilterExpression != nil {
+		sz, err := bu.Policy.FilterExpression.size()
 		if err != nil {
 			return -1, err
 		}
-		size += sz + int(_FIELD_HEADER_SIZE) + 1
+		size += sz + int(_FIELD_HEADER_SIZE)
+	}
+
+	if sendKey && bu.Key.hasValueToSend() {
+		if sz, err := bu.Key.userKey.EstimateSize(); err != nil {
+			return -1, err
+		} else {
+			size += sz + int(_FIELD_HEADER_SIZE) + 1
+		}
 	}
 
 	size += len(bu.PackageName) + int(_FIELD_HEADER_SIZE)

--- a/batch_udf.go
+++ b/batch_udf.go
@@ -85,8 +85,10 @@ func (bu *BatchUDF) equals(obj BatchRecordIfc) bool {
 
 // resolveSendKey returns parent ∪ per-record/default/dynamic sendKey. For internal use only.
 func (bu *BatchUDF) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
-	udfPolicy := client.getUsableBatchUDFPolicy(bu.Policy)
-	return parentPolicy.SendKey || (udfPolicy != nil && udfPolicy.SendKey)
+	// sendKey is the union of parent, cluster default and per-record (up carries dynamic config).
+	def := client.DefaultBatchUDFPolicy
+	up := client.getUsableBatchUDFPolicy(bu.Policy)
+	return parentPolicy.SendKey || (def != nil && def.SendKey) || (up != nil && up.SendKey)
 }
 
 // Return wire protocol size. sendKey is pre-resolved so size and write agree. For internal use only.

--- a/batch_udf_policy.go
+++ b/batch_udf_policy.go
@@ -148,7 +148,10 @@ func (bup *BatchUDFPolicy) mapDynamic(dynConfig *DynConfig) *BatchUDFPolicy {
 		}
 		if currentConfig.Dynamic.BatchUdf.SendKey != nil {
 			configValue := *currentConfig.Dynamic.BatchUdf.SendKey
-			bup.SendKey = configValue
+			// Dynamic config sendKey only overrides when true.
+			if configValue {
+				bup.SendKey = true
+			}
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SendKey set to %t", configValue)
 			}

--- a/batch_write.go
+++ b/batch_write.go
@@ -67,8 +67,10 @@ func (bw *BatchWrite) equals(obj BatchRecordIfc) bool {
 
 // resolveSendKey returns parent ∪ per-record/default/dynamic sendKey. For internal use only.
 func (bw *BatchWrite) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
+	// sendKey is the union of parent, cluster default and per-record (wp carries dynamic config).
+	def := client.DefaultBatchWritePolicy
 	wp := client.getUsableBatchWritePolicy(bw.Policy)
-	return parentPolicy.SendKey || (wp != nil && wp.SendKey)
+	return parentPolicy.SendKey || (def != nil && def.SendKey) || (wp != nil && wp.SendKey)
 }
 
 // Return wire protocol size. sendKey is pre-resolved so size and write agree. For internal use only.

--- a/batch_write.go
+++ b/batch_write.go
@@ -65,32 +65,30 @@ func (bw *BatchWrite) equals(obj BatchRecordIfc) bool {
 	return &bw.Ops == &other.Ops && bw.Policy == other.Policy && (bw.Policy == nil || !bw.Policy.SendKey)
 }
 
-// Return wire protocol size. For internal use only.
-func (bw *BatchWrite) size(parentPolicy *BasePolicy) (int, Error) {
+// resolveSendKey returns parent ∪ per-record/default/dynamic sendKey. For internal use only.
+func (bw *BatchWrite) resolveSendKey(parentPolicy *BasePolicy, client *Client) bool {
+	wp := client.getUsableBatchWritePolicy(bw.Policy)
+	return parentPolicy.SendKey || (wp != nil && wp.SendKey)
+}
+
+// Return wire protocol size. sendKey is pre-resolved so size and write agree. For internal use only.
+func (bw *BatchWrite) size(sendKey bool) (int, Error) {
 	size := 2 // gen(2) = 2
 
-	if bw.Policy != nil {
-		if bw.Policy.FilterExpression != nil {
-			if sz, err := bw.Policy.FilterExpression.size(); err != nil {
-				return -1, err
-			} else {
-				size += sz + int(_FIELD_HEADER_SIZE)
-			}
-		}
-
-		if (bw.Policy.SendKey || parentPolicy.SendKey) && bw.Key.hasValueToSend() {
-			if sz, err := bw.Key.userKey.EstimateSize(); err != nil {
-				return -1, err
-			} else {
-				size += sz + int(_FIELD_HEADER_SIZE) + 1
-			}
-		}
-	} else if parentPolicy.SendKey && bw.Key.hasValueToSend() {
-		sz, err := bw.Key.userKey.EstimateSize()
-		if err != nil {
+	if bw.Policy != nil && bw.Policy.FilterExpression != nil {
+		if sz, err := bw.Policy.FilterExpression.size(); err != nil {
 			return -1, err
+		} else {
+			size += sz + int(_FIELD_HEADER_SIZE)
 		}
-		size += sz + int(_FIELD_HEADER_SIZE) + 1
+	}
+
+	if sendKey && bw.Key.hasValueToSend() {
+		if sz, err := bw.Key.userKey.EstimateSize(); err != nil {
+			return -1, err
+		} else {
+			size += sz + int(_FIELD_HEADER_SIZE) + 1
+		}
 	}
 
 	hasWrite := false

--- a/batch_write_policy.go
+++ b/batch_write_policy.go
@@ -166,7 +166,10 @@ func (bwp *BatchWritePolicy) mapDynamic(dynConfig *DynConfig) *BatchWritePolicy 
 		}
 		if currentConfig.Dynamic.BatchWrite.SendKey != nil {
 			configValue := *currentConfig.Dynamic.BatchWrite.SendKey
-			bwp.SendKey = configValue
+			// Dynamic config sendKey only overrides when true.
+			if configValue {
+				bwp.SendKey = true
+			}
 			if dynConfig.logUpdate.Load() {
 				logger.Logger.Info("SendKey set to %t", configValue)
 			}

--- a/client.go
+++ b/client.go
@@ -934,6 +934,8 @@ func (clnt *Client) BatchDelete(policy *BatchPolicy, deletePolicy *BatchDeletePo
 
 	attr := &batchAttr{}
 	attr.setBatchDelete(deletePolicy)
+	// Union the parent BatchPolicy sendKey — setBatchDelete only reads the per-record policy.
+	attr.sendKey = attr.sendKey || policy.SendKey
 
 	// same array can be used without synchronization;
 	// when a key exists, the corresponding index will be set to record
@@ -1001,6 +1003,8 @@ func (clnt *Client) BatchExecute(policy *BatchPolicy, udfPolicy *BatchUDFPolicy,
 
 	attr := &batchAttr{}
 	attr.setBatchUDF(udfPolicy)
+	// Union the parent BatchPolicy sendKey — setBatchUDF only reads the per-record policy.
+	attr.sendKey = attr.sendKey || policy.SendKey
 
 	// same array can be used without synchronization;
 	// when a key exists, the corresponding index will be set to record

--- a/command.go
+++ b/command.go
@@ -252,13 +252,14 @@ type baseCommand struct {
 // Multi-record Transactions
 //--------------------------------------------------
 
-func canRepeat(policy *BatchPolicy, key *Key, record, prev BatchRecordIfc, ver, verPrev *uint64) bool {
+func canRepeat(key *Key, record, prev BatchRecordIfc, ver, verPrev *uint64) bool {
 	// Avoid relatively expensive full equality checks for performance reasons.
 	// Use reference equality only in hope that common namespaces/bin names are set from
 	// fixed variables.  It's fine if equality not determined correctly because it just
 	// results in more space used. The batch will still be correct.
 	// Same goes for ver reference equality check.
-	return !policy.SendKey && verPrev == ver && prev != nil && prev.key().namespace == key.namespace &&
+	// sendKey is gated by the caller (!sendKey && canRepeat) so reads keep repeat in a write batch.
+	return verPrev == ver && prev != nil && prev.key().namespace == key.namespace &&
 		prev.key().setName == key.setName && record == prev
 }
 
@@ -1184,9 +1185,10 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 
 		cmd.dataOffset += len(key.digest) + 4
 
+		sendKey := record.resolveSendKey(&policy.BasePolicy, client)
 		// Try reference equality in hope that namespace/set for all keys is set from fixed variables.
-		// if !policy.SendKey && prev != nil && prev.key().namespace == key.namespace && (prev.key().setName == key.setName) && record.equals(prev) {
-		if canRepeat(policy, key, record, prev, ver, verPrev) {
+		// if !sendKey && prev != nil && prev.key().namespace == key.namespace && (prev.key().setName == key.setName) && record.equals(prev) {
+		if !sendKey && canRepeat(key, record, prev, ver, verPrev) {
 			// Can set repeat previous namespace/bin names to save space.
 			cmd.dataOffset++
 		} else {
@@ -1195,7 +1197,7 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 			cmd.dataOffset += len(key.namespace) + int(_FIELD_HEADER_SIZE)
 			cmd.dataOffset += len(key.setName) + int(_FIELD_HEADER_SIZE)
 			cmd.sizeTxnBatch(txn, ver, record.BatchRec().hasWrite)
-			if sz, err := record.size(&policy.BasePolicy); err != nil {
+			if sz, err := record.size(sendKey); err != nil {
 				return nil, err
 			} else {
 				cmd.dataOffset += sz
@@ -1245,10 +1247,11 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 		if _, err := cmd.Write(key.digest[:]); err != nil {
 			return nil, newCommonError(err)
 		}
+		sendKey := record.resolveSendKey(&policy.BasePolicy, client)
 
 		// Try reference equality in hope that namespace/set for all keys is set from fixed variables.
-		// if !policy.SendKey && prev != nil && prev.key().namespace == key.namespace && prev.key().setName == key.setName && record.equals(prev) {
-		if canRepeat(policy, key, record, prev, ver, verPrev) {
+		// if !sendKey  && prev != nil && prev.key().namespace == key.namespace && prev.key().setName == key.setName && record.equals(prev) {
+		if !sendKey && canRepeat(key, record, prev, ver, verPrev) {
 			// Can set repeat previous namespace/bin names to save space.
 			cmd.WriteByte(_BATCH_MSG_REPEAT) // repeat
 		} else {
@@ -1274,8 +1277,9 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 
 			case _BRT_BATCH_WRITE:
 				bw := record.(*BatchWrite)
-
-				attr.setBatchWrite(client.getUsableBatchWritePolicy(bw.Policy))
+				usableWp := client.getUsableBatchWritePolicy(bw.Policy)
+				attr.setBatchWrite(usableWp)
+				attr.sendKey = sendKey // resolved union (parent honored)
 				attr.adjustWrite(bw.Ops)
 				if err := cmd.writeBatchOperations(key, txn, ver, bw.Ops, attr, attr.filterExp); err != nil {
 					return nil, err
@@ -1283,8 +1287,9 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 
 			case _BRT_BATCH_UDF:
 				bu := record.(*BatchUDF)
-
-				attr.setBatchUDF(client.getUsableBatchUDFPolicy(bu.Policy))
+				usableUp := client.getUsableBatchUDFPolicy(bu.Policy)
+				attr.setBatchUDF(usableUp)
+				attr.sendKey = sendKey
 				cmd.writeBatchWrite(key, txn, ver, attr, attr.filterExp, 3, 0)
 				cmd.writeFieldString(bu.PackageName, UDF_PACKAGE_NAME)
 				cmd.writeFieldString(bu.FunctionName, UDF_FUNCTION)
@@ -1292,8 +1297,9 @@ func (cmd *baseCommand) setBatchOperateIfcOffsets(
 
 			case _BRT_BATCH_DELETE:
 				bd := record.(*BatchDelete)
-
-				attr.setBatchDelete(client.getUsableBatchDeletePolicy(bd.Policy))
+				usableDp := client.getUsableBatchDeletePolicy(bd.Policy)
+				attr.setBatchDelete(usableDp)
+				attr.sendKey = sendKey
 				cmd.writeBatchWrite(key, txn, ver, attr, attr.filterExp, 0, 0)
 			}
 			prev = record
@@ -1372,8 +1378,9 @@ func (cmd *baseCommand) setBatchOperateReadOffsets(
 		cmd.dataOffset += len(key.digest) + 4
 
 		// Try reference equality in hope that namespace/set for all keys is set from fixed variables.
-		// if !policy.SendKey && prev != nil && prev.key().namespace == key.namespace && (prev.key().setName == key.setName) && record.equals(prev) {
-		if canRepeat(policy, key, record, prev, ver, verPrev) {
+		// if prev != nil && prev.key().namespace == key.namespace && (prev.key().setName == key.setName) && record.equals(prev) {
+		// Read-only path: reads never send the key, so repeat is not gated on sendKey.
+		if canRepeat(key, record, prev, ver, verPrev) {
 			// Can set repeat previous namespace/bin names to save space.
 			cmd.dataOffset++
 		} else {
@@ -1382,7 +1389,7 @@ func (cmd *baseCommand) setBatchOperateReadOffsets(
 			cmd.dataOffset += len(key.namespace) + int(_FIELD_HEADER_SIZE)
 			cmd.dataOffset += len(key.setName) + int(_FIELD_HEADER_SIZE)
 			cmd.sizeTxnBatch(txn, ver, record.BatchRec().hasWrite)
-			if sz, err := record.size(&policy.BasePolicy); err != nil {
+			if sz, err := record.size(false); err != nil {
 				return nil, err
 			} else {
 				cmd.dataOffset += sz
@@ -1434,8 +1441,9 @@ func (cmd *baseCommand) setBatchOperateReadOffsets(
 		}
 
 		// Try reference equality in hope that namespace/set for all keys is set from fixed variables.
-		// if !policy.SendKey && prev != nil && prev.key().namespace == key.namespace && prev.key().setName == key.setName && record.equals(prev) {
-		if canRepeat(policy, key, record, prev, ver, verPrev) {
+		// if prev != nil && prev.key().namespace == key.namespace && prev.key().setName == key.setName && record.equals(prev) {
+		// Read records never store the user key — repeat is not gated on sendKey.
+		if canRepeat(key, record, prev, ver, verPrev) {
 			// Can set repeat previous namespace/bin names to save space.
 			cmd.WriteByte(_BATCH_MSG_REPEAT) // repeat
 		} else {

--- a/dynconfig_serialze_test.go
+++ b/dynconfig_serialze_test.go
@@ -151,10 +151,8 @@ var _ = gg.Describe("CLIENT-4898 dynamic config sendKey override", func() {
 	ns := *namespace
 	set := "ck4898_dyn"
 
-	// Single self-contained test (does not use the shared batch sendKey helpers).
-	//
-	// Guarantee: dynamic config can only ENABLE sendKey, never DISABLE an API-set value, and it
-	// must never mutate the caller's policy object (patchDynamic works on a copy).
+	// Self-contained (no shared helpers): dynamic config only enables sendKey, never disables an
+	// API-set value, and never mutates the caller's policy.
 	gg.It("dynamic config can only enable sendKey, never disable it, and never mutates the caller policy", func() {
 		// Fresh dynconfig-enabled client per scheme (config is wired at client construction).
 		withClient := func(url string) (*as.Client, func()) {

--- a/dynconfig_serialze_test.go
+++ b/dynconfig_serialze_test.go
@@ -16,10 +16,13 @@ package aerospike_test
 
 import (
 	"fmt"
+	"strconv"
 
 	"gopkg.in/yaml.v3"
 
+	as "github.com/aerospike/aerospike-client-go/v8"
 	dynconfig "github.com/aerospike/aerospike-client-go/v8/config"
+	registry "github.com/aerospike/aerospike-client-go/v8/config/registry"
 	gg "github.com/onsi/ginkgo/v2"
 	gm "github.com/onsi/gomega"
 )
@@ -117,4 +120,102 @@ var _ = gg.Describe("YAML Unmarshal for Enum Types", func() {
 		gg.Entry("quoted invalid", `"badval"`, nil, true),
 		gg.Entry("number", "123", nil, true),
 	)
+})
+
+// In-memory dynamic-config provider (same shape as fakeConfigProvider in client_test.go).
+type sendKeyDynProvider struct{ cfg *dynconfig.Config }
+
+func (p *sendKeyDynProvider) LoadConfig(dsn string) *dynconfig.Config { return p.cfg }
+
+// Register the fixture schemes ONCE at tree-construction time (registry.Register panics on a
+// duplicate scheme, so this must not run inside a BeforeEach/It). Each scheme carries send_key
+// for write, UDF and delete so dynamic config applies to every batch write type.
+var _ = func() bool {
+	mk := func(sendKey bool) *sendKeyDynProvider {
+		sk, version := sendKey, "1.0.0"
+		return &sendKeyDynProvider{cfg: &dynconfig.Config{
+			Version: &version,
+			Dynamic: &dynconfig.DynamicConfig{
+				BatchWrite:  &dynconfig.BatchWrite{SendKey: &sk},
+				BatchUdf:    &dynconfig.BatchUdf{SendKey: &sk},
+				BatchDelete: &dynconfig.BatchDelete{SendKey: &sk},
+			},
+		}}
+	}
+	registry.Register("sendkeytrue://", mk(true))
+	registry.Register("sendkeyfalse://", mk(false))
+	return true
+}()
+
+var _ = gg.Describe("CLIENT-4898 dynamic config sendKey override", func() {
+	ns := *namespace
+	set := "ck4898_dyn"
+
+	// Single self-contained test (does not use the shared batch sendKey helpers).
+	//
+	// Guarantee: dynamic config can only ENABLE sendKey, never DISABLE an API-set value, and it
+	// must never mutate the caller's policy object (patchDynamic works on a copy).
+	gg.It("dynamic config can only enable sendKey, never disable it, and never mutates the caller policy", func() {
+		// Fresh dynconfig-enabled client per scheme (config is wired at client construction).
+		withClient := func(url string) (*as.Client, func()) {
+			orig := as.AEROSPIKE_CLIENT_CONFIG_URL
+			as.AEROSPIKE_CLIENT_CONFIG_URL = url
+			c, err := as.NewClientWithPolicyAndHost(clientPolicy, dbHosts...)
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+			return c, func() { c.Close(); as.AEROSPIKE_CLIENT_CONFIG_URL = orig }
+		}
+
+		// Did the server store the user key for this digest? A scan is the only correct probe —
+		// the client otherwise supplies the key itself.
+		stored := func(key *as.Key) bool {
+			rs, err := client.ScanAll(as.NewScanPolicy(), ns, set)
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+			defer rs.Close()
+			for res := range rs.Results() {
+				if res.Record != nil && res.Record.Key != nil &&
+					string(res.Record.Key.Digest()) == string(key.Digest()) {
+					return res.Record.Key.Value() != nil
+				}
+			}
+			return false
+		}
+
+		// Run a 3-record batch write with the given per-record sendKey on a dynconfig client.
+		run := func(url string, apiSendKey bool, prefix string) []*as.Key {
+			c, cleanup := withClient(url)
+			defer cleanup()
+			wp := as.NewBatchWritePolicy()
+			wp.SendKey = apiSendKey
+			var recs []as.BatchRecordIfc
+			var keys []*as.Key
+			for i := 0; i < 3; i++ {
+				k, _ := as.NewKey(ns, set, prefix+strconv.Itoa(i))
+				keys = append(keys, k)
+				recs = append(recs, as.NewBatchWrite(wp, k, as.PutOp(as.NewBin("v", i))))
+			}
+			gm.Expect(c.BatchOperate(as.NewBatchPolicy(), recs)).ToNot(gm.HaveOccurred())
+			return keys
+		}
+
+		// API sendKey=true + dynamic send_key=false → must STAY stored (dynamic cannot disable).
+		for _, k := range run("sendkeyfalse://dummy", true, "dyn-sticky-") {
+			gm.Expect(stored(k)).To(gm.BeTrue(), "dynamic send_key=false must not disable an API-set sendKey=true")
+		}
+
+		// API sendKey=false + dynamic send_key=true → must become stored (dynamic enables).
+		for _, k := range run("sendkeytrue://dummy", false, "dyn-enable-") {
+			gm.Expect(stored(k)).To(gm.BeTrue(), "dynamic send_key=true must enable sendKey")
+		}
+
+		// The caller's policy object must never be mutated by dynamic config.
+		c, cleanup := withClient("sendkeytrue://dummy")
+		defer cleanup()
+		wp := as.NewBatchWritePolicy()
+		wp.SendKey = false
+		k, _ := as.NewKey(ns, set, "dyn-nomutate")
+		recs := []as.BatchRecordIfc{as.NewBatchWrite(wp, k, as.PutOp(as.NewBin("v", 1)))}
+		gm.Expect(c.BatchOperate(as.NewBatchPolicy(), recs)).ToNot(gm.HaveOccurred())
+		gm.Expect(wp.SendKey).To(gm.BeFalse(), "dynamic config must apply to a copy, not the caller's policy")
+		gm.Expect(stored(k)).To(gm.BeTrue())
+	})
 })


### PR DESCRIPTION
In a `batch`, consecutive same-namespace/set records can use a 1-byte "`repeat`" marker instead of a full header — but a record carrying its own user key can't repeat. The old code gated this on the parent `BatchPolicy.SendKey`, so enabling sendKey for writes in a mixed batch wrongly stripped the repeat flag from the reads too (reads never send a key). The fix gates on each record's **resolved** sendKey (reads = always false), so reads keep the repeat optimization in mixed write batches — smaller payloads, no behavior change.