### PR TITLE
Fix batch read panic on split retry: nil records in batchCommandOperate.inDoubt

### DIFF
--- a/batch_command_indoubt_test.go
+++ b/batch_command_indoubt_test.go
@@ -236,6 +236,31 @@ var _ = gg.Describe("Batch multi-key write in-doubt propagation (CLIENT-5000)", 
 		})
 	})
 
+	// batchIndexCommandGet embeds batchCommandOperate but keeps its records in
+	// its own []*BatchRead field; newBatchIndexCommandGet leaves the embedded
+	// records slice nil, which is why the type overrides generateBatchNodes and
+	// nsIter. Without an inDoubt override too, a split retry's setInDoubt reaches
+	// the promoted batchCommandOperate.inDoubt and indexes that nil slice with
+	// this subcommand's offsets, panicking with "index out of range".
+	gg.Context("batchIndexCommandGet (batch read)", func() {
+		gg.It("never marks reads in-doubt and does not touch the embedded nil records slice", func() {
+			records := []*BatchRead{
+				NewBatchRead(nil, mkKey(0), []string{"a"}),
+				NewBatchRead(nil, mkKey(1), []string{"a"}),
+				NewBatchRead(nil, mkKey(2), []string{"a"}),
+			}
+
+			cmd := newBatchIndexCommandGet(nil, &batchNode{offsets: []int{1, 2}}, NewBatchPolicy(), records, true)
+
+			cmd.setInDoubt(&cmd)
+
+			for i, br := range records {
+				gm.Expect(br.InDoubt).To(gm.BeFalse(), "read %d must never be in-doubt", i)
+				gm.Expect(br.ResultCode).To(gm.Equal(types.NO_RESPONSE), "read %d must be left untouched", i)
+			}
+		})
+	})
+
 	// CLIENT-5000 bug #1: retryBatch sets the parent's splitRetry=true before
 	// cloning subcommands, and cloneBatchCommand is a shallow copy, so each clone
 	// inherits splitRetry=true and its own setInDoubt becomes a no-op. clearSplitRetry

--- a/batch_index_command_get.go
+++ b/batch_index_command_get.go
@@ -255,6 +255,12 @@ func (cmd *batchIndexCommandGet) parseRecord(key *Key, opCount int, generation, 
 	return newRecord(cmd.node, key, bins, generation, expiration), nil
 }
 
+// inDoubt does nothing: this command only reads, and reads are never in-doubt.
+// The override is required because the promoted batchCommandOperate.inDoubt
+// would index the embedded (nil) records slice with this command's offsets.
+func (cmd *batchIndexCommandGet) inDoubt() {
+}
+
 func (cmd *batchIndexCommandGet) generateBatchNodes(cluster *Cluster) ([]*batchNode, Error) {
 	return newBatchNodeListRecords(cluster, cmd.policy, cmd.records, cmd.sequenceAP, cmd.sequenceSC, cmd.batch)
 }


### PR DESCRIPTION
### Problem

A `BatchGetComplex` (batch read) that is retried and split across nodes panics:

```
panic: runtime error: index out of range [8] with length 0
(*batchCommandOperate).inDoubt   batch_command_operate.go:314
(*batchCommand).setInDoubt       batch_command.go:57
(*batchCommand).retryBatch       batch_command.go:134
(*baseCommand).executeAt         command.go:3754
(*batchIndexCommandGet).Execute  batch_index_command_get.go:67
```

Client v8.8.0, 3-node cluster, default `ReplicaPolicy` (`SEQUENCE`). Seen in production under read timeouts.

### Cause

`batchIndexCommandGet` embeds `batchCommandOperate` but holds its records in its own `records []*BatchRead` field; `newBatchIndexCommandGet` passes `nil` for `batchCommandOperate.records`. That is why it already overrides `generateBatchNodes` and `nsIter`.

v8.8.0 added `batchCommandOperate.inDoubt()`, which iterates `cmd.batch.offsets` and indexes `cmd.records`. `batchIndexCommandGet` does not override it, so `retryBatch` -> `setInDoubt` reaches the promoted method and indexes the nil slice. `failFastInDoubt` has the same problem. v8.7.0 had no `batchCommandOperate.inDoubt`, so the `batchCommand` no-op default applied and there was no panic.

### Fix

```go
// inDoubt does nothing: this command only reads, and reads are never in-doubt.
func (cmd *batchIndexCommandGet) inDoubt() {
}
```

Consistent with `batchIndexCommandGet.Execute`, which (unlike `batchCommandOperate.Execute`) never calls `setInDoubt`.

### Test

`batch_index_command_get_indoubt_test.go` is an in-package unit test, no server needed. It builds the subcommand in its post-timeout shape and drives `setInDoubt`, as `retryBatch` does. It panics with the exact production message without the fix, and asserts the read records are left untouched with it.
